### PR TITLE
Updating CLI Exceptions Logic And Some Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For JSON respond, add `--json` to the command.
 
 ### create-project
 
-Run `./cli.sh create-project --name {project name} --dut_type {dut type}` to create a new project. DUT Type must be one of `Controller, Accessory`.
+Run `./cli.sh create-project --name {project name} --config {config file}` to create a new project. Project name is required.
 
 ### list-projects
 

--- a/app/api_lib_autogen/models.py
+++ b/app/api_lib_autogen/models.py
@@ -25,16 +25,12 @@ class BodyCreateTestRunExecutionApiV1TestRunExecutionsPost(BaseModel):
     selected_tests: "Optional[Dict[str, Dict[str, Dict[str, int]]]]" = Field(None, alias="selected_tests")
 
 
-# class BodyUploadFileApiV1TestRunExecutionsFileUploadPost(BaseModel):
-# file: "IO[Any]" = Field(..., alias="file")
-
-
 class DutConfig(BaseModel):
     discriminator: "str" = Field(..., alias="discriminator")
     setup_code: "str" = Field(..., alias="setup_code")
     pairing_mode: "DutPairingModeEnum" = Field(..., alias="pairing_mode")
-    ip_address: "Optional[str]" = Field(None, alias="ip_address")
-    port: "Optional[str]" = Field(None, alias="port")
+    chip_timeout: "Optional[str]" = Field(None, alias="chip_timeout")
+    chip_use_paa_certs: "Optional[bool]" = Field(False, alias="chip_use_paa_certs")
 
 
 class DutPairingModeEnum(str, Enum):

--- a/app/commands/run_tests.py
+++ b/app/commands/run_tests.py
@@ -36,7 +36,7 @@ test_run_executions_api = async_apis.test_run_executions_api
     "--selected-tests",
     "-s",
     help="JSON string with selected tests. "
-    'Format: \'{"collection_name":{"test_suite_id":{"test_case_id": <iterations>}}}\'',
+    'Format Example: \'{"SDK YAML Tests":{"FirstChipToolSuite":{"TC-ACE-1.1": 1}}}\'',
 )
 @click.option(
     "--title", default=lambda: str(datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")), show_default="timestamp"
@@ -54,16 +54,18 @@ async def run_tests(selected_tests: str, title: str, file: str, project_id: int)
     # Configure new log output for test.
     log_path = test_logging.configure_logger_for_run(title=title)
 
-    selected_tests_dict = __parse_selected_tests(selected_tests, file)
-
-    new_test_run = await __create_new_test_run(selected_tests=selected_tests_dict, title=title, project_id=project_id)
-    socket = TestRunSocket(new_test_run)
-    socket_task = asyncio.create_task(socket.connect_websocket())
-    new_test_run = await __start_test_run(new_test_run)
-    socket.run = new_test_run
-    await socket_task
-    await client.aclose()
-    click.echo(f"Log output in: '{log_path}'")
+    try:
+        selected_tests_dict = __parse_selected_tests(selected_tests, file)
+        new_test_run = await __create_new_test_run(selected_tests=selected_tests_dict, title=title, project_id=project_id)
+        socket = TestRunSocket(new_test_run)
+        socket_task = asyncio.create_task(socket.connect_websocket())
+        new_test_run = await __start_test_run(new_test_run)
+        socket.run = new_test_run
+        await socket_task
+        click.echo(f"Log output in: '{log_path}'")
+    finally:
+        await client.aclose()
+    
 
 
 async def __create_new_test_run(selected_tests: dict, title: str, project_id: int) -> None:

--- a/app/commands/test_run_execution_history.py
+++ b/app/commands/test_run_execution_history.py
@@ -57,13 +57,15 @@ def test_run_execution_history(
     id: Optional[int], skip: Optional[int], limit: Optional[int], json: Optional[bool]
 ) -> None:
     """Read test run execution history"""
-    if id is not None:
-        __test_run_execution_by_id(id, json)
-    elif skip is not None or limit is not None:
-        __test_run_execution_batch(json, skip, limit)
-    else:
-        __test_run_execution_batch(json)
-    client.close()
+    try:
+        if id is not None:
+            __test_run_execution_by_id(id, json)
+        elif skip is not None or limit is not None:
+            __test_run_execution_batch(json, skip, limit)
+        else:
+            __test_run_execution_batch(json)
+    finally:
+        client.close()
 
 
 def __test_run_execution_by_id(id: int, json: bool) -> None:

--- a/app/test_run/socket_schemas.py
+++ b/app/test_run/socket_schemas.py
@@ -63,15 +63,15 @@ class TestRunUpdate(TestUpdateBase):
 
 
 class TestSuiteUpdate(TestUpdateBase):
-    test_suite_execution_id: int
+    test_suite_execution_index: int
 
 
 class TestCaseUpdate(TestSuiteUpdate):
-    test_case_execution_id: int
+    test_case_execution_index: int
 
 
 class TestStepUpdate(TestCaseUpdate):
-    test_step_execution_id: int
+    test_step_execution_index: int
 
 
 class TestUpdate(BaseModel):

--- a/app/test_run/websocket.py
+++ b/app/test_run/websocket.py
@@ -104,20 +104,20 @@ class TestRunSocket:
         click.echo(f"Test Run [{str(update.state.name)}]")
 
     def __log_test_suite_update(self, update: TestSuiteUpdate) -> None:
-        suite = self.__suite(update.test_suite_execution_id)
+        suite = self.__suite(update.test_suite_execution_index)
         title = suite.test_suite_metadata.title
         click.echo(f"  - {title} [{str(update.state.name)}]")
 
     def __log_test_case_update(self, update: TestCaseUpdate) -> None:
-        case = self.__case(id=update.test_case_execution_id, suite_id=update.test_suite_execution_id)
+        case = self.__case(index=update.test_case_execution_index, suite_index=update.test_suite_execution_index)
         title = case.test_case_metadata.title
         click.echo(f"      - {title} [{str(update.state.name)}]")
 
     def __log_test_step_update(self, update: TestStepUpdate) -> None:
         step = self.__step(
-            id=update.test_step_execution_id,
-            case_id=update.test_case_execution_id,
-            suite_id=update.test_suite_execution_id,
+            index=update.test_step_execution_index,
+            case_index=update.test_case_execution_index,
+            suite_index=update.test_suite_execution_index,
         )
         if step is not None:
             title = step.title
@@ -127,13 +127,13 @@ class TestRunSocket:
         for record in records:
             logger.log(record.level, record.message)
 
-    def __suite(self, id: int) -> TestSuiteExecution:
-        return next((s for s in self.run.test_suite_executions if s.id == id))
+    def __suite(self, index: int) -> TestSuiteExecution:
+        return self.run.test_suite_executions[index]
 
-    def __case(self, id: int, suite_id: int) -> TestCaseExecution:
-        suite = self.__suite(suite_id)
-        return next((c for c in suite.test_case_executions if c.id == id))
+    def __case(self, index: int, suite_index: int) -> TestCaseExecution:
+        suite = self.__suite(suite_index)
+        return suite.test_case_executions[index]
 
-    def __step(self, id: int, case_id: int, suite_id: int) -> Optional[TestStepExecution]:
-        case = self.__case(id=case_id, suite_id=suite_id)
-        return next((s for s in case.test_step_executions if s.id == id), None)
+    def __step(self, index: int, case_index: int, suite_index: int) -> Optional[TestStepExecution]:
+        case = self.__case(index=case_index, suite_index=suite_index)
+        return case.test_step_executions[index]

--- a/cli.sh
+++ b/cli.sh
@@ -15,4 +15,6 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
-poetry run python3 app/main.py $@
+#Using an array to store the arguments, to handle 'whitespaces' correctly
+args=("$@")
+poetry run python3 app/main.py "${args[@]}"


### PR DESCRIPTION
## What Changed:

The exceptions logic were updated to always close the httpx client.
Plus, some bugs were addressed for the following CLI options:
- create-project (create without config file)
- list-projects (list one specific project id)
- run-tests (whitespaces were breaking the `--selected-tests` argument)

Also, the socket response was updated to receive index values instead of IDs.
Finally, a minor correction in the `README.md` file, removing an unexisting argument and adding the missing `--config` option.

Fixes: https://github.com/project-chip/certification-tool/issues/155