### PR TITLE
Add --tests-list argument to run-tests CLI command

### DIFF
--- a/app/commands/run_tests.py
+++ b/app/commands/run_tests.py
@@ -35,14 +35,19 @@ test_collections_api = async_apis.test_collections_api
 def build_test_selection(test_collections, tests_list) -> dict:
     """Build the test selection JSON structure from test_collections and tests_list.
     Example:
-        tests_list = ["TC-ACE-1.1", "TC_ACE_1_3"]
-        test_collections = {
-            "SDK YAML Tests": {
-                "FirstChipToolSuite": {
+        tests_list = "TC-ACE-1.1,TC_ACE_1_3"
+        Selected tests: {
+                "SDK YAML Tests": {
+                    "FirstChipToolSuite": {
                     "TC-ACE-1.1": 1
+                    }
+                },
+                "SDK Python Tests": {
+                    "Python Testing Suite": {
+                    "TC_ACE_1_3": 1
+                    }
                 }
             }
-        }
     """
     selected_tests = {}
 

--- a/app/commands/run_tests.py
+++ b/app/commands/run_tests.py
@@ -29,6 +29,49 @@ from test_run.websocket import TestRunSocket
 
 async_apis = AsyncApis(client)
 test_run_executions_api = async_apis.test_run_executions_api
+test_collections_api = async_apis.test_collections_api
+
+
+def build_test_selection(test_collections, tests_list) -> dict:
+    """Build the test selection JSON structure from test_collections and tests_list.
+    Example:
+        tests_list = ["TC-ACE-1.1", "TC_ACE_1_3"]
+        test_collections = {
+            "SDK YAML Tests": {
+                "FirstChipToolSuite": {
+                    "TC-ACE-1.1": 1
+                }
+            }
+        }
+    """
+    selected_tests = {}
+
+    # Convert test IDs to a set for faster lookup and normalize them
+    tests_set = {test_id.strip().replace("-", "_").replace(".", "_") for test_id in tests_list}
+
+    # Iterate through test collections
+    for collection_name, collection in test_collections.test_collections.items():
+        selected_tests[collection_name] = {}
+
+        # Iterate through test suites
+        for suite_name, suite in collection.test_suites.items():
+            selected_tests[collection_name][suite_name] = {}
+
+            # Iterate through test cases
+            for test_case_id, test_case in suite.test_cases.items():
+                # Normalize the test case ID for comparison
+                normalized_test_case_id = test_case_id.replace("-", "_").replace(".", "_")
+                if normalized_test_case_id in tests_set:
+                    selected_tests[collection_name][suite_name][test_case_id] = 1
+
+    # Remove empty collections and suites
+    selected_tests = {
+        collection: {suite: tests for suite, tests in suites.items() if tests}
+        for collection, suites in selected_tests.items()
+        if any(suites.values())
+    }
+
+    return selected_tests
 
 
 @click.command()
@@ -48,16 +91,31 @@ test_run_executions_api = async_apis.test_run_executions_api
     required=True,
     help="Project ID that this test run belongs to",
 )
+@click.option(
+    "--tests-list",
+    help="List of test cases to execute. For example: TC-ACE-1.1,TC_ACE_1_3",
+)
 @async_cmd
-async def run_tests(selected_tests: str, title: str, file: str, project_id: int) -> None:
+async def run_tests(selected_tests: str, title: str, file: str, project_id: int, tests_list: str = None) -> None:
     """Create a new test run from selected tests"""
 
     # Configure new log output for test.
     log_path = test_logging.configure_logger_for_run(title=title)
 
     try:
-        selected_tests_dict = __parse_selected_tests(selected_tests, file)
-        new_test_run = await __create_new_test_run(selected_tests=selected_tests_dict, title=title, project_id=project_id)
+        # Check if tests_list is provided
+        if tests_list:
+            # Convert each test separeted by comma to a list
+            tests_list = [test for test in tests_list.split(",")]
+            test_collections = await test_collections_api.read_test_collections_api_v1_test_collections_get()
+            selected_tests_dict = build_test_selection(test_collections, tests_list)
+        else:
+            selected_tests_dict = __parse_selected_tests(selected_tests, file)
+
+        click.echo(f"Selected tests: {json.dumps(selected_tests_dict, indent=2)}")
+        new_test_run = await __create_new_test_run(
+            selected_tests=selected_tests_dict, title=title, project_id=project_id
+        )
         socket = TestRunSocket(new_test_run)
         socket_task = asyncio.create_task(socket.connect_websocket())
         new_test_run = await __start_test_run(new_test_run)
@@ -66,7 +124,6 @@ async def run_tests(selected_tests: str, title: str, file: str, project_id: int)
         click.echo(f"Log output in: '{log_path}'")
     finally:
         await client.aclose()
-    
 
 
 async def __create_new_test_run(selected_tests: dict, title: str, project_id: int) -> None:

--- a/app/commands/run_tests.py
+++ b/app/commands/run_tests.py
@@ -93,7 +93,7 @@ def build_test_selection(test_collections, tests_list) -> dict:
 )
 @click.option(
     "--tests-list",
-    help="List of test cases to execute. For example: TC-ACE-1.1,TC_ACE_1_3",
+    help="List of test cases to execute. Separated by commas (,) and without any blank spaces. For example: TC-ACE-1.1,TC_ACE_1_3",
 )
 @async_cmd
 async def run_tests(selected_tests: str, title: str, file: str, project_id: int, tests_list: str = None) -> None:


### PR DESCRIPTION
### What Changed
The goal of this PR is to allow CLI to just receive a list of test cases to perform a test run. Currently the CLI requires the whole test case hierarchy. The `run-tests` command can now receive  `--tests-list` as argument,

### Related issue
https://github.com/project-chip/certification-tool/issues/615

### Testing
The user should be able to perform a test run just by passing the test case Ids: `./cli.sh run-tests --project-id 15 --tests-list TC-ACE-1.1,TC_ACE_1_3`
<img width="495" alt="Screenshot 2025-05-26 at 15 29 08" src="https://github.com/user-attachments/assets/c199a956-7ed2-455d-aee7-606ba6a98dd4" />


[test_run_2025-05-26-18:26:08.log](https://github.com/user-attachments/files/20444888/test_run_2025-05-26-18.26.08.log)
