### PR TITLE
Added support to PICS for run-tests-cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Run `./cli.sh update-project --id {id} --config path/to/config` to update a proj
 
 ### run-tests-cli
 
-Run `./cli.sh run-tests-cli --tests-list <tests> [--title <title>] [-c <config>]` to execute a test run using the simplified CLI flow.
+Run `./cli.sh run-tests-cli --tests-list <tests> [--title <title>] [-c <config>] [--pics-config-folder <pics-config-folder>]` to execute a test run using the simplified CLI flow.
 
 This command simplifies test execution by allowing you to run selected test cases directly, with minimal configuration defined in a property file.
 
@@ -106,6 +106,7 @@ Example: --tests-list TC-ACE-1.1,TC_ACE_1_3
 Optional:
 --title: Custom title for the test run. If not provided, the current timestamp will be used as the default.
 --config: Path to the property config file. If not specified, default_config.properties will be used.
+--pics-config-folder: Path to the PICS file. If not specified, no PICS file will be used.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Example: --tests-list TC-ACE-1.1,TC_ACE_1_3
 Optional:
 --title: Custom title for the test run. If not provided, the current timestamp will be used as the default.
 --config: Path to the property config file. If not specified, default_config.properties will be used.
---pics-config-folder: Path to the PICS file. If not specified, no PICS file will be used.
+--pics-config-folder: Path to the folder that contains PICS files. If not specified, no PICS file will be used.
 
 ## Development
 

--- a/app/api_lib_autogen/docs/BodyCreateTestRunExecutionCliApiV1TestRunExecutionsCliPost.md
+++ b/app/api_lib_autogen/docs/BodyCreateTestRunExecutionCliApiV1TestRunExecutionsCliPost.md
@@ -1,0 +1,11 @@
+# BodyCreateTestRunExecutionCliApiV1TestRunExecutionsCliPost
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**test_run_execution_in** | [**TestRunExecutionCreate**](TestRunExecutionCreate.md) |  | 
+**selected_tests** | **dict(str, dict(str, dict(str, int)))** |  | [optional] 
+**config** | **dict(str, object)** |  | [optional] 
+**pics** | **dict(str, object)** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md) 

--- a/app/api_lib_autogen/models.py
+++ b/app/api_lib_autogen/models.py
@@ -27,6 +27,7 @@ class BodyCreateTestRunExecutionApiV1TestRunExecutionsPost(BaseModel):
 
 class BodyCreateTestRunExecutionCliApiV1TestRunExecutionsCliPost(BodyCreateTestRunExecutionApiV1TestRunExecutionsPost):
     config: "Dict[str, Any]" = Field(default_factory=dict, alias="config")
+    pics: "Optional[Dict[str, Any]]" = Field(None, alias="pics")
 
 
 class DutConfig(BaseModel):
@@ -174,6 +175,7 @@ class TestRunExecutionCreate(BaseModel):
     project_id: "Optional[int]" = Field(None, alias="project_id")
     description: "Optional[str]" = Field(None, alias="description")
     operator_id: "Optional[int]" = Field(None, alias="operator_id")
+    pics: "Optional[Dict[str, Any]]" = Field(None, alias="pics")
 
 
 class TestRunExecutionInDBBase(BaseModel):

--- a/app/commands/run_tests.py
+++ b/app/commands/run_tests.py
@@ -53,7 +53,7 @@ test_collections_api = async_apis.test_collections_api
 @click.option(
     "--tests-list",
     help="List of test cases to execute. Separated by commas (,) and without any blank spaces. "
-        "For example: TC-ACE-1.1,TC_ACE_1_3",
+    "For example: TC-ACE-1.1,TC_ACE_1_3",
 )
 @async_cmd
 async def run_tests(selected_tests: str, title: str, file: str, project_id: int, tests_list: str = None) -> None:


### PR DESCRIPTION
### What changed
The goal of this PR is to add support for PICS argument to the existing run-tests-cli command. The idea is the add `--pics-config-folder [pics_folder]` optional argument while running run-tests-cli.

### Related Issue
https://github.com/project-chip/certification-tool/issues/627

### Testing
Run `./cli.shrun-tests-cli --config cli_config.properties --tests-list TC-ACE-1.1 --pics-config-folder app/pics_tst` successfuly