### PR TITLE
Log the PICS config used in test run

### DIFF
--- a/app/commands/run_tests_cli.py
+++ b/app/commands/run_tests_cli.py
@@ -86,8 +86,7 @@ async def run_tests_cli(title: str, config: str, tests_list: str, pics_config_fo
 
     # Read PICS configuration if provided
     pics = read_pics_config(pics_config_folder)
-
-    click.echo(f"PICS Used: {pics}")
+    click.echo(f"PICS Used: {json.dumps(pics, indent=2)}")
 
     try:
         # Convert each test separeted by comma to a list

--- a/app/commands/run_tests_cli.py
+++ b/app/commands/run_tests_cli.py
@@ -87,6 +87,8 @@ async def run_tests_cli(title: str, config: str, tests_list: str, pics_config_fo
     # Read PICS configuration if provided
     pics = read_pics_config(pics_config_folder)
 
+    click.echo(f"PICS Used: {pics}")
+
     try:
         # Convert each test separeted by comma to a list
         tests_list = [test for test in tests_list.split(",")]


### PR DESCRIPTION
### What changed
Prints the PICS config used in test run

### Related Issue
https://github.com/project-chip/certification-tool/issues/699

### Testing
<img width="1308" height="520" alt="Screenshot 2025-08-13 at 16 04 32" src="https://github.com/user-attachments/assets/9f2de719-8949-4d1f-989d-50c2baf47649" />
