### PR TITLE
[Feature] Add CLI Auto Complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CLI tool for using the CSA Test Harness
 ## Setup
 
 1. Open terminal in the root folder and run the command `./scripts/th_cli_install.sh`
-2. Change the url in config.json as required:
+2. Change the url in config.json if required:
 
 ```json
     "hostname" : "192.168.x.x" //Change this to your Raspberry Pi IP address/localhost for local development
@@ -50,7 +50,6 @@ Commands:
   delete-project              Deletes a project
   list-projects               Get a list of projects
   run-tests                   Create a new test run from selected tests
-  run-tests-cli               Simplified CLI execution of a test run from selected tests
   test-run-execution-history  Read test run execution history
   test-runner-status          Get the current Matter test runner status
   update-project              Updates a project with full test env config file
@@ -63,9 +62,16 @@ Run `th-cli available-tests` to get a list of tests available in Test Harness, p
 
 ### run-tests
 
-Run `th-cli run-tests --file /path/to/file --project-id {id}` to run a test.
+Run `th-cli run-tests --tests-list <tests> [--title, -n <title>] [--config, -c <config>] [--pics-config-folder, -p <pics-config-folder>] [--project-id <ID>]` to start a new test execution.
 
-A `test config json` and `project ID` is required. For example, `{"sample_tests":{"SampleTestSuite1":{"TCSS1001": 1}}}`. Keys `sample_tests`, `SampleTestSuite1` and `TCSS1001` is mapped to the results from command `available-tests`. This triggers backend to run Test Case TCSS1001 once. Change the number to run a Test Case multiple times. Project id indicates which project this test run belongs to.
+Required:
+- `--tests-list`: Comma-separated list of test case identifiers (e.g. --tests-list TC-ACE-1.1,TC_ACE_1_3)
+
+Optional:
+- `--title`: Custom title for the test run. If not provided, the current timestamp will be used as the default.
+- `--config`: Path to the property config file. If not specified, default_config.properties will be used.
+- `--pics-config-folder`: Path to the folder that contains PICS files. If not specified, no PICS file will be used.
+- `--project-id`: Project ID that this test run belongs to. If not provided, uses the default 'CLI Execution Project' in TH.
 
 ### test-run-execution-history
 
@@ -93,26 +99,11 @@ Run `th-cli delete-project --id {id}` to delete a project.
 
 ### update-project
 
-Run `th-cli update-project --id {id} --config path/to/config` to update a project. Both parameters are required. Config must be a full test environment config file.
-
-### run-tests-cli
-
-Run `th-cli run-tests-cli --tests-list <tests> [--title <title>] [-c <config>] [--pics-config-folder <pics-config-folder>]` to execute a test run using the simplified CLI flow.
-
-This command simplifies test execution by allowing you to run selected test cases directly, with minimal configuration defined in a property file.
-
-Required:
---tests-list: Comma-separated list of test case identifiers.
-Example: --tests-list TC-ACE-1.1,TC_ACE_1_3
-
-Optional:
---title: Custom title for the test run. If not provided, the current timestamp will be used as the default.
---config: Path to the property config file. If not specified, default_config.properties will be used.
---pics-config-folder: Path to the folder that contains PICS files. If not specified, no PICS file will be used.
+Run `th-cli update-project --id {id} --config {config file}` to update a project. Both parameters are required. Config must be a full test environment config file.
 
 ## Development
 
-The source files are organized in `./th_cli`.
+The source files are organized in `./th_cli/`.
 
 ### Add new command
 

--- a/scripts/th_cli_install.sh
+++ b/scripts/th_cli_install.sh
@@ -21,39 +21,42 @@ set -e
 # Initialize a variable to hold the arguments for pipx.
 PIPX_ARGS="--force"
 
-# Check the first argument passed to the script.
+# Check the arguments passed to the script.
 if [[ "$1" == "--editable" ]]; then
   echo "Running in --editable mode."
   PIPX_ARGS="$PIPX_ARGS --editable"
 fi
 # --- End of Argument Handling ---
 
+# --- Variables ---
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+COMPLETION_FILE=".th-cli-complete"
+# --- End of Variables ---
 
 echo "Installing Matter CLI..."
 
 # Check if pipx is installed
 if ! command -v pipx &> /dev/null; then
-    echo "Installing pipx..."
-    # Checking for root privileges before running sudo
-    if [[ $EUID -ne 0 ]]; then
-       echo "Sudo privileges are required to install pipx."
-       sudo apt update
-    else
-       apt update
-    fi
-    sudo apt install -y pipx
-    pipx ensurepath
-    # [Optional] To allow pipx actions with --global argument use the below line
-    # sudo pipx ensurepath --global
-    export PATH="$HOME/.local/bin:$PATH"
+  echo "Installing pipx..."
+
+  # Checking for root privileges before running sudo
+  if [[ $EUID -ne 0 ]]; then
+    echo "Sudo privileges are required to install pipx."
+    sudo apt update
+  else
+    apt update
+  fi
+
+  sudo apt install -y pipx
+  pipx ensurepath
+  export PATH="$HOME/.local/bin:$PATH"
 fi
 
 # Running Poetry install
 echo "Running Poetry..."
 if ! command -v poetry &> /dev/null; then
-    echo "Poetry could not be found. Please ensure it is installed and in your PATH."
-    exit 1
+  echo "Poetry could not be found. Please ensure it is installed and in your PATH."
+  exit 1
 fi
 poetry self update
 poetry --project="$PROJECT_ROOT" install
@@ -67,7 +70,39 @@ echo "Installing with pipx..."
 cd "$PROJECT_ROOT"
 pipx install . $PIPX_ARGS
 
+echo "Setting up shell completion..."
+
+# Detect shell and set up completion feature
+# Note: The expected shell to be installed for Test Harness is currently bash.
+# However, an example on how to handle multiples shells is provided below.
+if [ -n "$BASH_VERSION" ]; then
+  SHELL_TYPE="bash"
+  COMPLETION_FILE="$HOME/$COMPLETION_FILE.bash"
+  RC_FILE="$HOME/.bashrc"
+elif [ -n "$ZSH_VERSION" ]; then
+  SHELL_TYPE="zsh"
+  COMPLETION_FILE="$HOME/$COMPLETION_FILE.zsh"
+  RC_FILE="$HOME/.zshrc"
+else
+  echo "Shell detection failed. Setting up for bash..."
+  SHELL_TYPE="bash"
+  COMPLETION_FILE="$HOME/$COMPLETION_FILE.bash"
+  RC_FILE="$HOME/.bashrc"
+fi
+
+# Generate completion script
+_TH_CLI_COMPLETE=${SHELL_TYPE}_source th-cli > "$COMPLETION_FILE"
+echo "Generated completion script at $COMPLETION_FILE"
+
+# Add source line to RC file if not already present
+if ! grep -q "source $COMPLETION_FILE" "$RC_FILE" 2>/dev/null; then
+  echo "source $COMPLETION_FILE" >> "$RC_FILE"
+  source $RC_FILE
+  echo "Added completion source to $RC_FILE"
+fi
+
 echo ""
-echo "Installation complete!"
+echo "Installation complete! 🎉"
 echo ""
 echo "To test: th-cli --help"
+echo "To enable shell completion, restart your terminal or run: 'source $RC_FILE'"

--- a/th_cli/commands/available_tests.py
+++ b/th_cli/commands/available_tests.py
@@ -29,7 +29,7 @@ from th_cli.utils import __json_string, __print_json
 @click.option(
     "--json",
     is_flag=True,
-    flag_value=True,
+    default=False,
     help="Print JSON response for more details",
 )
 def available_tests(json: bool = False) -> None:
@@ -50,7 +50,7 @@ def available_tests(json: bool = False) -> None:
     except CLIError:
         raise  # Re-raise CLI Errors as-is
     except UnexpectedResponse as e:
-        handle_api_error(e, f"get available tests")
+        handle_api_error(e, "get available tests")
     except Exception as e:
         raise CLIError(
             f"Could not fetch the available tests: {e}. Please check if the API server is running and accessible."

--- a/th_cli/commands/project.py
+++ b/th_cli/commands/project.py
@@ -46,9 +46,9 @@ def _abort_if_false(ctx, value):
     "--config",
     "-c",
     required=False,
-    type=str,
+    type=click.Path(file_okay=True, dir_okay=False),
     default=None,
-    help="Config file for the project",
+    help="Config JSON file for the project",
 )
 def create_project(name: str, config: Optional[str]) -> None:
     """Create a new project"""
@@ -159,7 +159,7 @@ def delete_project(id: int) -> None:
 @click.option(
     "--json",
     is_flag=True,
-    flag_value=True,
+    default=False,
     help="Print JSON response for more details",
 )
 def list_projects(
@@ -247,8 +247,8 @@ def list_projects(
     "--config",
     "-c",
     required=True,
-    type=str,
-    help="New config file path",
+    type=click.Path(exists=True, dir_okay=False),
+    help="New config JSON file path",
 )
 def update_project(id: int, config: str):
     """Updates project with full test environment config file"""

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -55,6 +55,7 @@ from th_cli.validation import validate_directory_path, validate_file_path, valid
 @click.option(
     "--config",
     "-c",
+    type=click.Path(file_okay=True, dir_okay=False),
     help="Property config file location. This "
     "information is optional — if not provided, the default_config.properties "
     "file will be used.",
@@ -62,6 +63,7 @@ from th_cli.validation import validate_directory_path, validate_file_path, valid
 @click.option(
     "--pics-config-folder",
     "-p",
+    type=click.Path(file_okay=False, dir_okay=True),
     help="Directory containing PICS XML configuration files. If not provided, no PICS will be used.",
 )
 @click.option(

--- a/th_cli/commands/test_run_execution_history.py
+++ b/th_cli/commands/test_run_execution_history.py
@@ -54,6 +54,7 @@ table_format = "{:<5} {:30} {:10} {:40}"
 @click.option(
     "--json",
     is_flag=True,
+    default=False,
     help="Print JSON response for more details",
 )
 def test_run_execution_history(

--- a/th_cli/commands/test_runner_status.py
+++ b/th_cli/commands/test_runner_status.py
@@ -26,6 +26,7 @@ from th_cli.utils import __print_json
 @click.option(
     "--json",
     is_flag=True,
+    default=False,
     help="Print JSON response for more details",
 )
 def test_runner_status(json: Optional[bool]) -> None:
@@ -35,7 +36,7 @@ def test_runner_status(json: Optional[bool]) -> None:
         client = get_client()
         sync_apis = SyncApis(client)
         test_run_execution_api = sync_apis.test_run_executions_api
-        
+
         test_runner_status = test_run_execution_api.get_test_runner_status_api_v1_test_run_executions_status_get()
         if json:
             __print_json(test_runner_status)

--- a/th_cli/commands/versions.py
+++ b/th_cli/commands/versions.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import subprocess
 
 import click
@@ -32,13 +31,13 @@ def get_cli_version() -> str:
         # Try package root first
         package_root = get_package_root()
         pyproject_path = package_root / "pyproject.toml"
-        
+
         if not pyproject_path.exists():
             # If not found in package root, try git root
             git_root = find_git_root()
             if git_root:
                 pyproject_path = git_root / "pyproject.toml"
-        
+
         if pyproject_path.exists():
             with open(pyproject_path, "rb") as f:
                 pyproject_data = tomli.load(f)
@@ -49,6 +48,7 @@ def get_cli_version() -> str:
     except (FileNotFoundError, IOError):
         return "unknown"
 
+
 def get_cli_sha() -> str:
     """Get current CLI SHA from git"""
     try:
@@ -56,7 +56,7 @@ def get_cli_sha() -> str:
         git_root = find_git_root()
         if not git_root:
             return "unknown"
-        
+
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True,

--- a/th_cli/config.py
+++ b/th_cli/config.py
@@ -31,6 +31,7 @@ def get_package_root() -> Path:
     # Get the directory containing this config.py file
     return Path(__file__).parent.parent
 
+
 def find_git_root() -> Path | None:
     """
     Find the root directory containing the CLI's .git folder.
@@ -38,21 +39,22 @@ def find_git_root() -> Path | None:
     """
     # Start from the package root
     current_path = get_package_root()
-    
+
     # Walk up the directory tree looking for .git
     while current_path != current_path.parent:
         if (current_path / ".git").exists():
             return current_path
         current_path = current_path.parent
-    
+
     # If not found in package location, try current working directory
     current_path = Path.cwd()
     while current_path != current_path.parent:
         if (current_path / ".git").exists():
             return current_path
         current_path = current_path.parent
-    
+
     return None
+
 
 def is_editable_install() -> bool:
     """
@@ -60,7 +62,7 @@ def is_editable_install() -> bool:
     """
     package_root = get_package_root()
     git_root = find_git_root()
-    
+
     # If git root and package root are the same, it's likely editable
     if git_root and package_root:
         try:
@@ -71,25 +73,26 @@ def is_editable_install() -> bool:
             return False
     return False
 
+
 def get_config_search_paths() -> list[Path]:
     """
     Get a list of paths to search for configuration files.
     """
     paths = []
-    
+
     # Always include current working directory
     paths.append(Path.cwd())
-    
+
     # Include package installation directory
     package_root = get_package_root()
     paths.append(package_root)
-    
+
     # If not editable install, also check git root (original source)
     if not is_editable_install():
         git_root = find_git_root()
         if git_root and git_root != package_root:
             paths.append(git_root)
-    
+
     return paths
 
 
@@ -120,12 +123,12 @@ def load_config():
     """Load configuration with fallbacks"""
     # Get dynamic search paths
     search_paths = get_config_search_paths()
-    
+
     # Try different possible locations for config files
     possible_locations = []
     for path in search_paths:
         possible_locations.append(path / "config.json")
-    
+
     for config_path in possible_locations:
         if config_path.exists():
             try:
@@ -133,12 +136,12 @@ def load_config():
             except Exception as e:
                 CLIError(f"Could not load config from {config_path}: {e}")
                 continue
-    
+
     # Try to create config from example file
     example_locations = []
     for path in search_paths:
         example_locations.append(path / "config.json.example")
-    
+
     for example_path in example_locations:
         if example_path.exists():
             try:
@@ -150,7 +153,7 @@ def load_config():
             except Exception as e:
                 print(f"Warning: Could not load example config from {example_path}: {e}")
                 continue
-    
+
     # Fall back to default configuration
     print("Warning: Using default configuration")
     default_config = get_default_config()

--- a/th_cli/main.py
+++ b/th_cli/main.py
@@ -22,7 +22,6 @@ from th_cli.commands import (
     delete_project,
     list_projects,
     run_tests,
-    run_tests_cli,
     test_run_execution_history,
     test_runner_status,
     update_project,
@@ -46,7 +45,6 @@ root.add_command(test_run_execution_history)
 root.add_command(test_runner_status)
 root.add_command(delete_project)
 root.add_command(update_project)
-root.add_command(run_tests_cli)
 root.add_command(versions)
 
 


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/698
---

## Description
Add the completion feature to the TH CLI install script to auto configure the Test harness environment and use the `th-cli` app with completion.

## Testing
After running the `./scripts/th_cli_install.sh` script, source the shell configuration file (e.g. `source ~/.bashrc`) and test using the `th-cli` and completing pressing with \<TAB\> like the example below:

```sh
ubuntu@matter:~/certification-tool/cli$ th-cli <TAB> <TAB>
available-tests             delete-project              run-tests                   test-run-execution-history  update-project              
create-project              list-projects               run-tests-cli               test-runner-status          versions
```

Also tested typing a command partially and pressing \<TAB\> to fill the rest, or after typing a command, you may type `--` and press \<TAB\> twice to see the available flags for that command, like demonstrated below:

```sh
 th-cli run-tests --
--tests-list          --title               --config              --pics-config-folder  --project-id          --help
```

Finally, the type of some command options were updated to Path (file and/or directory) for a better experience completing flags that require those. The example below only show directories for the `--pics-config-folder` completion:

```sh
ubuntu@matter:~/certification-tool/cli$ th-cli run-tests --pics-config-folder <TAB> <TAB>
.mypy_cache/      .venv/            .devcontainer/    .github/          client_generator/ dist/             scripts/          th_cli/           .vscode/          output_logs/ 
```

---
Plus: Updated README file and removed remaining `test_run_cli` usage.