### PR TITLE
Implement abort command

### DIFF
--- a/th_cli/commands/__init__.py
+++ b/th_cli/commands/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from .abort_testing import abort_testing
 from .available_tests import available_tests
 from .project import create_project, delete_project, list_projects, update_project
 from .run_tests import run_tests
@@ -21,6 +22,7 @@ from .test_runner_status import test_runner_status
 from .versions import versions
 
 __all__ = [
+    "abort_testing",
     "available_tests",
     "create_project",
     "delete_project",

--- a/th_cli/commands/abort_testing.py
+++ b/th_cli/commands/abort_testing.py
@@ -33,6 +33,8 @@ def abort_testing() -> None:
 
         response = test_run_executions_api.abort_testing_api_v1_test_run_executions_abort_testing_post()
         click.echo(response.get("detail", "Testing aborted"))
+    except CLIError:
+        raise  # Re-raise CLI Errors as-is
     except UnexpectedResponse as e:
         handle_api_error(e, "abort testing")
     finally:

--- a/th_cli/commands/abort_testing.py
+++ b/th_cli/commands/abort_testing.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import click
+
+from th_cli.api_lib_autogen.api_client import SyncApis
+from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
+from th_cli.client import get_client
+from th_cli.exceptions import handle_api_error
+
+
+@click.command()
+def abort_testing() -> None:
+    """Cancel the current testing"""
+    client = None
+    try:
+        client = get_client()
+        sync_apis = SyncApis(client)
+        test_run_executions_api = sync_apis.test_run_executions_api
+
+        response = test_run_executions_api.abort_testing_api_v1_test_run_executions_abort_testing_post()
+        click.echo(response.get("detail", "Testing aborted"))
+    except UnexpectedResponse as e:
+        handle_api_error(e, "abort testing")
+    finally:
+        if client:
+            client.close()

--- a/th_cli/main.py
+++ b/th_cli/main.py
@@ -17,12 +17,12 @@
 import click
 
 from th_cli.commands import (
+    abort_testing,
     available_tests,
     create_project,
     delete_project,
     list_projects,
     run_tests,
-    run_tests_cli,
     test_run_execution_history,
     test_runner_status,
     update_project,
@@ -38,6 +38,7 @@ def root() -> None:
     pass
 
 
+root.add_command(abort_testing)
 root.add_command(available_tests)
 root.add_command(create_project)
 root.add_command(list_projects)
@@ -46,7 +47,6 @@ root.add_command(test_run_execution_history)
 root.add_command(test_runner_status)
 root.add_command(delete_project)
 root.add_command(update_project)
-root.add_command(run_tests_cli)
 root.add_command(versions)
 
 


### PR DESCRIPTION
### What Changed
Implement abort command. In the end, this command calls the POST `abort-testing` backend endpoint.

### Related Issue
https://github.com/project-chip/certification-tool/issues/711

### Testing
Calling abort after star a test run (`th-cli run-tests --tests-list TC-ACE-1.3 -p pics_tst --project-id 5`), worked properly.

<img width="582" height="34" alt="Screenshot 2025-08-26 at 15 18 07" src="https://github.com/user-attachments/assets/265eacce-c857-48ee-9128-a0321ebce132" />


<img width="694" height="432" alt="Screenshot 2025-08-26 at 15 18 18" src="https://github.com/user-attachments/assets/cb5130bb-e387-4e9d-b8aa-5a1fd2877c98" />
