### PR TITLE
Implement show execution log

### DIFF
--- a/th_cli/api_lib_autogen/api_client.py
+++ b/th_cli/api_lib_autogen/api_client.py
@@ -22,15 +22,9 @@ from pydantic import ValidationError, parse_obj_as
 from th_cli.api_lib_autogen.api.devices_api import AsyncDevicesApi, SyncDevicesApi
 from th_cli.api_lib_autogen.api.operators_api import AsyncOperatorsApi, SyncOperatorsApi
 from th_cli.api_lib_autogen.api.projects_api import AsyncProjectsApi, SyncProjectsApi
-from th_cli.api_lib_autogen.api.test_collections_api import (
-    AsyncTestCollectionsApi,
-    SyncTestCollectionsApi,
-)
+from th_cli.api_lib_autogen.api.test_collections_api import AsyncTestCollectionsApi, SyncTestCollectionsApi
 from th_cli.api_lib_autogen.api.test_run_configs_api import AsyncTestRunConfigsApi, SyncTestRunConfigsApi
-from th_cli.api_lib_autogen.api.test_run_executions_api import (
-    AsyncTestRunExecutionsApi,
-    SyncTestRunExecutionsApi,
-)
+from th_cli.api_lib_autogen.api.test_run_executions_api import AsyncTestRunExecutionsApi, SyncTestRunExecutionsApi
 from th_cli.api_lib_autogen.api.utils_api import AsyncUtilsApi, SyncUtilsApi
 from th_cli.api_lib_autogen.api.versions_api import AsyncVersionsApi, SyncVersionsApi
 from th_cli.api_lib_autogen.exceptions import ResponseHandlingException, UnexpectedResponse
@@ -86,12 +80,14 @@ class ApiClient:
     @overload
     async def request(
         self, *, type_: Type[T], method: str, url: str, path_params: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> T: ...
+    ) -> T:
+        ...
 
     @overload  # noqa F811
     async def request(
         self, *, type_: None, method: str, url: str, path_params: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> None: ...
+    ) -> None:
+        ...
 
     async def request(  # noqa F811
         self, *, type_: Any, method: str, url: str, path_params: Optional[Dict[str, Any]] = None, **kwargs: Any
@@ -103,10 +99,12 @@ class ApiClient:
         return await self.send(request, type_)
 
     @overload
-    def request_sync(self, *, type_: Type[T], **kwargs: Any) -> T: ...
+    def request_sync(self, *, type_: Type[T], **kwargs: Any) -> T:
+        ...
 
     @overload  # noqa F811
-    def request_sync(self, *, type_: None, **kwargs: Any) -> None: ...
+    def request_sync(self, *, type_: None, **kwargs: Any) -> None:
+        ...
 
     def request_sync(self, *, type_: Any, **kwargs: Any) -> Any:  # noqa F811
         """
@@ -118,6 +116,8 @@ class ApiClient:
         response = await self.middleware(request, self.send_inner)
         if response.status_code in [200, 201]:
             try:
+                if type_ is type(None):
+                    return response.text
                 return parse_obj_as(type_, response.json())
             except ValidationError as e:
                 raise ResponseHandlingException(e)

--- a/th_cli/api_lib_autogen/api_client.py
+++ b/th_cli/api_lib_autogen/api_client.py
@@ -116,7 +116,7 @@ class ApiClient:
         response = await self.middleware(request, self.send_inner)
         if response.status_code in [200, 201]:
             try:
-                if type_ is type(None):
+                if type_ is None:
                     return response.text
                 return parse_obj_as(type_, response.json())
             except ValidationError as e:

--- a/th_cli/commands/__init__.py
+++ b/th_cli/commands/__init__.py
@@ -18,6 +18,7 @@ from .available_tests import available_tests
 from .project import create_project, delete_project, list_projects, update_project
 from .run_tests import run_tests
 from .test_run_execution_history import test_run_execution_history
+from .test_run_execution_log import test_run_execution_log
 from .test_runner_status import test_runner_status
 from .versions import versions
 
@@ -29,6 +30,7 @@ __all__ = [
     "list_projects",
     "run_tests",
     "test_run_execution_history",
+    "test_run_execution_log",
     "update_project",
     "test_runner_status",
     "versions",

--- a/th_cli/commands/test_run_execution_log.py
+++ b/th_cli/commands/test_run_execution_log.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2025 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/th_cli/commands/test_run_execution_log.py
+++ b/th_cli/commands/test_run_execution_log.py
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Optional
+
+import click
+
+from th_cli.api_lib_autogen.api_client import SyncApis
+from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
+from th_cli.client import get_client
+from th_cli.exceptions import CLIError, handle_api_error
+
+
+@click.command()
+@click.option(
+    "--id",
+    "-i",
+    required=True,
+    type=int,
+    help="Test Run Execution ID to fetch logs for",
+)
+def test_run_execution_log(id: int) -> None:
+    """Print test execution log for a given test run execution ID"""
+    client = None
+    try:
+        client = get_client()
+        sync_apis = SyncApis(client)
+        __fetch_test_run_execution_log(sync_apis, id)
+    except CLIError:
+        raise  # Re-raise CLI Errors as-is
+    finally:
+        if client:
+            client.close()
+
+
+def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int) -> None:
+    try:
+        test_run_execution_api = sync_apis.test_run_executions_api
+        log_content = test_run_execution_api.download_log_api_v1_test_run_executions_id_log_get(
+            id=id, json_entries=False, download=False
+        )
+
+        if log_content:
+            click.echo(log_content)
+        else:
+            click.echo("No log content available for this test run execution.")
+
+    except UnexpectedResponse as e:
+        handle_api_error(e, "fetch test run execution log")

--- a/th_cli/main.py
+++ b/th_cli/main.py
@@ -24,6 +24,7 @@ from th_cli.commands import (
     list_projects,
     run_tests,
     test_run_execution_history,
+    test_run_execution_log,
     test_runner_status,
     update_project,
     versions,
@@ -44,6 +45,7 @@ root.add_command(create_project)
 root.add_command(list_projects)
 root.add_command(run_tests)
 root.add_command(test_run_execution_history)
+root.add_command(test_run_execution_log)
 root.add_command(test_runner_status)
 root.add_command(delete_project)
 root.add_command(update_project)


### PR DESCRIPTION
### What changed
Implement show execution log command

### Related issue
https://github.com/project-chip/certification-tool/issues/713

### Testing
This command `th-cli test-run-execution-log  --id 176` runs successfully 
<img width="1306" height="674" alt="Screenshot 2025-09-01 at 14 50 55" src="https://github.com/user-attachments/assets/100e1b4b-747c-4776-b9aa-d160600b4c51" />
