### PR TITLE
Add color to test_run_execution_log command and code formating

### DIFF
--- a/th_cli/commands/available_tests.py
+++ b/th_cli/commands/available_tests.py
@@ -28,7 +28,7 @@ from th_cli.utils import __json_string, __print_json
 
 @click.command(
     short_help=colorize_help("List all available test cases"),
-    help=colorize_cmd_help("available_tests", "Get a list of the available test cases")
+    help=colorize_cmd_help("available_tests", "Get a list of the available test cases"),
 )
 @click.option(
     "--json",

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -32,7 +32,7 @@ from th_cli.colorize import (
     colorize_help,
     colorize_key_value,
     italic,
-    set_colors_enabled
+    set_colors_enabled,
 )
 from th_cli.exceptions import CLIError, handle_api_error
 from th_cli.test_run.websocket import TestRunSocket

--- a/th_cli/commands/test_run_execution_log.py
+++ b/th_cli/commands/test_run_execution_log.py
@@ -21,16 +21,20 @@ import click
 from th_cli.api_lib_autogen.api_client import SyncApis
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
 from th_cli.client import get_client
+from th_cli.colorize import colorize_cmd_help, colorize_help
 from th_cli.exceptions import CLIError, handle_api_error
 
 
-@click.command()
+@click.command(
+    short_help=colorize_help("Print test execution log for a given test run execution ID"),
+    help=colorize_cmd_help("test_run_execution_log", "Print test execution log for a given test run execution ID"),
+)
 @click.option(
     "--id",
     "-i",
     required=True,
     type=int,
-    help="Test Run Execution ID to fetch logs for",
+    help=colorize_help("Test Run Execution ID to fetch logs for"),
 )
 def test_run_execution_log(id: int) -> None:
     """Print test execution log for a given test run execution ID"""

--- a/th_cli/commands/test_runner_status.py
+++ b/th_cli/commands/test_runner_status.py
@@ -26,7 +26,7 @@ from th_cli.utils import __print_json
 
 @click.command(
     short_help=colorize_help("Get the current test runner status"),
-   help=colorize_cmd_help("test_runner_status", "Get the current test runner status")
+    help=colorize_cmd_help("test_runner_status", "Get the current test runner status"),
 )
 @click.option(
     "--json",

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -139,7 +139,7 @@ async def __prompt_user_for_file_upload(prompt: PromptRequest) -> str:
     """Prompt the user to provide a file path for upload."""
     # Print Prompt
     click.echo(prompt.prompt)
-    
+
     while True:
         click.echo("Enter the path to the file to upload (or press Enter to skip): ")
 
@@ -158,6 +158,7 @@ async def __prompt_user_for_file_upload(prompt: PromptRequest) -> str:
         await asyncio.sleep(0.1)
         click.echo(f"Invalid file path or type: {file_path}", err=True)
 
+
 async def __upload_file_and_send_response(
     socket: WebSocketClientProtocol, file_path: str, prompt: PromptRequest
 ) -> None:
@@ -169,24 +170,24 @@ async def __upload_file_and_send_response(
             return
 
         file_size = os.path.getsize(file_path)
-        
+
         # Check file size limit
         if file_size > MAX_FILE_SIZE:
             click.echo(f"❌ File too large: {file_size} bytes (max: {MAX_FILE_SIZE} bytes)", err=True)
             await __send_prompt_response(socket=socket, input="", prompt=prompt)
             return
-        
+
         click.echo(f"File selected: {file_path} (size: {file_size:,} bytes)")
 
         # Build upload URL - handle both hostname and hostname:port formats
         base_url = config.hostname
-        if not base_url.startswith(('http://', 'https://')):
+        if not base_url.startswith(("http://", "https://")):
             base_url = f"http://{base_url}"
         upload_url = f"{base_url}/api/v1/test_run_executions/file_upload/"
 
         async with httpx.AsyncClient() as client:
-            with open(file_path, 'rb') as file:
-                files = {'file': (os.path.basename(file_path), file, 'application/octet-stream')}
+            with open(file_path, "rb") as file:
+                files = {"file": (os.path.basename(file_path), file, "application/octet-stream")}
 
                 response = await client.post(upload_url, files=files)
 
@@ -207,6 +208,7 @@ async def __upload_file_and_send_response(
         click.echo(f"❌ Unexpected error uploading file: {str(e)}", err=True)
         await __send_prompt_response(socket=socket, input="", prompt=prompt)
 
+
 def __valid_text_input(input: Any, prompt: TextInputPromptRequest) -> bool:
     if not isinstance(input, str):
         return False
@@ -224,7 +226,7 @@ def __valid_file_upload(file_path: str, prompt: PromptRequest) -> bool:
         return False
 
     file_ext = os.path.splitext(file_path)[1].lower()
-    if file_ext not in ['.txt', '.log']:
+    if file_ext not in [".txt", ".log"]:
         click.echo(f"Error: Invalid file type '{file_ext}'. Only .txt and .log files are supported.", err=True)
         return False
 


### PR DESCRIPTION
### What changed
Added color to `test-run-execution-log` command and also code formatting after run back.

### Related Issue 
https://github.com/project-chip/certification-tool/issues/730

### Testing
<img width="682" height="138" alt="Screenshot 2025-09-03 at 10 53 12" src="https://github.com/user-attachments/assets/6ba03aee-3674-4bbf-97d2-4747bf1eea26" />
