### PR TITLE
Improved code that merge default_config with provided config

### DIFF
--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -200,9 +200,12 @@ def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
     Returns:
         Updated configuration dictionary with properties values mapped to the correct structure
     """
-    config_dict = copy.deepcopy(default_config)
-    # Convert default_config to dict if it's not already
-    config_dict = config_dict.__dict__ if hasattr(config_dict, "__dict__") else config_dict
+    if hasattr(default_config, "__dict__"):
+        default_dict = convert_nested_to_dict(default_config)
+    else:
+        default_dict = default_config
+
+    config_dict = copy.deepcopy(default_dict)
 
     def _convert_value(value: str, default_value: Any) -> Any:
         """Convert string value to appropriate type based on default value.

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -257,20 +257,16 @@ def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
 
     # Automatically merge all sections from config_data
     # Process both sections that exist in default_config and new sections from config_data
-    for section_name in config_data.keys():
-        if section_name in config_dict:
-            # Section exists in both - merge them
-            if (
-                isinstance(config_dict[section_name], dict)
-                and isinstance(config_data[section_name], dict)
-                and section_name in default_dict
-            ):
-                _deep_merge(config_dict[section_name], config_data[section_name], default_dict[section_name])
-            else:
-                config_dict[section_name] = config_data[section_name]
+    for section_name, section_value in config_data.items():
+        if (
+            section_name in config_dict
+            and section_name in default_dict
+            and isinstance(config_dict[section_name], dict)
+            and isinstance(section_value, dict)
+        ):
+            _deep_merge(config_dict[section_name], section_value, default_dict[section_name])
         else:
-            # Section only exists in config_data - add it directly
-            config_dict[section_name] = config_data[section_name]
+            config_dict[section_name] = section_value
 
     return config_dict
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -260,8 +260,12 @@ def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
     for section_name in config_data.keys():
         if section_name in config_dict:
             # Section exists in both - merge them
-            if isinstance(config_dict[section_name], dict) and isinstance(config_data[section_name], dict):
-                _deep_merge(config_dict[section_name], config_data[section_name], config_dict[section_name])
+            if (
+                isinstance(config_dict[section_name], dict)
+                and isinstance(config_data[section_name], dict)
+                and section_name in default_dict
+            ):
+                _deep_merge(config_dict[section_name], config_data[section_name], default_dict[section_name])
             else:
                 config_dict[section_name] = config_data[section_name]
         else:

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -188,6 +188,11 @@ def add_unmapped_property(properties: dict, key: str, value: str, current_sectio
 def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
     """Map properties values to the default_config structure.
 
+    This function automatically merges properties from config_data into default_config
+    by iterating through all sections present in the default config. This approach
+    ensures that future updates to the default configuration don't require changes
+    to this function.
+
     Args:
         config_data: Dictionary with properties values organized by main sections
         default_config: Dictionary with default configuration values
@@ -199,41 +204,66 @@ def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
     # Convert default_config to dict if it's not already
     config_dict = config_dict.__dict__ if hasattr(config_dict, "__dict__") else config_dict
 
-    # Process network section if it exists
-    if "network" in config_data:
-        # Create new network section
-        new_network = {}
+    def _convert_value(value: str, default_value: Any) -> Any:
+        """Convert string value to appropriate type based on default value.
 
-        # Process thread section
-        if "thread" in config_data["network"]:
-            new_network["thread"] = config_data["network"]["thread"]
+        Args:
+            value: String value from properties file
+            default_value: Default value to infer type from
 
-        # Process wifi section
-        if "wifi" in config_data["network"]:
-            new_network["wifi"] = config_data["network"]["wifi"]
+        Returns:
+            Converted value matching the type of default_value
+        """
+        if isinstance(default_value, bool):
+            return value.lower() == "true"
+        elif isinstance(default_value, int):
+            try:
+                return int(value)
+            except ValueError:
+                return value
+        elif isinstance(default_value, float):
+            try:
+                return float(value)
+            except ValueError:
+                return value
+        return value
+
+    def _deep_merge(target: dict, source: dict, default: dict) -> None:
+        """Recursively merge source into target, using default for type inference.
+
+        Args:
+            target: Target dictionary to merge into (modified in place)
+            source: Source dictionary to merge from
+            default: Default dictionary to infer types and structure from
+        """
+        for key, value in source.items():
+            if key not in target:
+                # Key doesn't exist in target, add it directly
+                target[key] = value
+            elif isinstance(value, dict) and isinstance(target.get(key), dict):
+                # Both are dictionaries, recurse
+                default_for_key = default.get(key, {}) if isinstance(default, dict) else {}
+                _deep_merge(target[key], value, default_for_key)
+            else:
+                # Leaf value - convert type if needed
+                default_value = default.get(key) if isinstance(default, dict) else None
+                if isinstance(value, str) and default_value is not None:
+                    target[key] = _convert_value(value, default_value)
+                else:
+                    target[key] = value
+
+    # Automatically merge all sections from config_data
+    # Process both sections that exist in default_config and new sections from config_data
+    for section_name in config_data.keys():
+        if section_name in config_dict:
+            # Section exists in both - merge them
+            if isinstance(config_dict[section_name], dict) and isinstance(config_data[section_name], dict):
+                _deep_merge(config_dict[section_name], config_data[section_name], config_dict[section_name])
+            else:
+                config_dict[section_name] = config_data[section_name]
         else:
-            new_network["wifi"] = config_dict["network"]["wifi"]
-
-        # Replace the entire network section
-        config_dict["network"] = new_network
-
-    # Process dut_config section
-    if "dut_config" in config_data:
-        dut_data = config_data["dut_config"]
-        if "pairing_mode" in dut_data:
-            config_dict["dut_config"]["pairing_mode"] = dut_data["pairing_mode"]
-        if "setup_code" in dut_data:
-            config_dict["dut_config"]["setup_code"] = dut_data["setup_code"]
-        if "discriminator" in dut_data:
-            config_dict["dut_config"]["discriminator"] = dut_data["discriminator"]
-        if "chip_use_paa_certs" in dut_data:
-            config_dict["dut_config"]["chip_use_paa_certs"] = dut_data["chip_use_paa_certs"].lower() == "true"
-        if "trace_log" in dut_data:
-            config_dict["dut_config"]["trace_log"] = dut_data["trace_log"].lower() == "true"
-
-    # Process test_parameters section
-    if "test_parameters" in config_data:
-        config_dict["test_parameters"] = config_data["test_parameters"]
+            # Section only exists in config_data - add it directly
+            config_dict[section_name] = config_data[section_name]
 
     return config_dict
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -223,12 +223,12 @@ def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
             try:
                 return int(value)
             except ValueError:
-                return value
+                raise CLIError(f"Invalid integer value '{value}' in properties file.")
         elif isinstance(default_value, float):
             try:
                 return float(value)
             except ValueError:
-                return value
+                raise CLIError(f"Invalid float value '{value}' in properties file.")
         return value
 
     def _deep_merge(target: dict, source: dict, default: dict) -> None:

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -189,7 +189,7 @@ def merge_properties_to_config(config_data: dict, default_config: dict) -> dict:
     """Map properties values to the default_config structure.
 
     This function automatically merges properties from config_data into default_config
-    by iterating through all sections present in the default config. This approach
+    by iterating through all sections present in the provided config_data. This approach
     ensures that future updates to the default configuration don't require changes
     to this function.
 


### PR DESCRIPTION
### What Changed
Refactored merge_properties_to_config function to use dynamic merging instead of hard-coded section processing, making it more maintainable and future-proof.   The previous implementation of merge_properties_to_config in /cli/th_cli/utils.py hard-coded specific sections (network, dut_config, test_parameters) and their individual fields. 

### Related issue
https://github.com/project-chip/certification-tool/issues/626

### Testing
  - Properties files with all standard sections (network, dut_config, test_parameters) are processed correctly
  - Boolean values (chip_use_paa_certs, trace_log) are converted properly
  - Integer values (rcp_baudrate, discriminator) are converted properly
  - Nested sections (network.thread, network.wifi) are merged correctly
  - Custom sections in properties files are preserved
  
  Execution using this command: `th_cli run-tests -t TC_ACE_1_3 -c /home/ubuntu/certification-tool/cli/th_cli/c2.properties ` merges the properties successfully 
  
  `c2.properties` file:

>   [network]
> fabric_id=0
> 
> [network.thread]
> channel=16
> panid=0x1234
> extpanid=1111111122222222
> networkkey=00112233445566778899aabbccddeeff
> networkname=DEMO
> rcp_serial_path=/dev/ttyACM0
> rcp_baudrate=115200
> on_mesh_prefix=fd11:22::/64
> network_interface=eth0
> 
> [network.wifi]
> ssid=testharness
> password=wifi-password
> 
> [dut_config]
> pairing_mode=onnetwork
> setup_code=20202021
> discriminator=3840
> chip_use_paa_certs=false
> trace_log=true
> 
> [test_parameters]
> endpoint=1
> 