### PR TITLE
Updated prompt_manager.py to show placeholder_text

### DIFF
--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -235,22 +235,22 @@ async def __prompt_user_for_text_input(prompt: TextInputPromptRequest) -> str:
 
     # Display default value if available
     prompt_suffix = ""
-    if prompt.default_value:
+    if prompt.default_value is not None:
         prompt_suffix = f" [default: {prompt.default_value}]"
 
     click.echo(f"Enter value{prompt_suffix}: ", nl=False)
 
     # Wait for input async
-    input = await aioconsole.ainput()
+    user_input = await aioconsole.ainput()
 
     # Use default value if input is empty and default exists
-    if not input.strip() and prompt.default_value:
-        input = prompt.default_value
-        click.echo(f"Using default value: {input}")
+    if not user_input.strip() and prompt.default_value is not None:
+        user_input = prompt.default_value
+        click.echo(f"Using default value: {user_input}")
 
     # validate input
-    if __valid_text_input(input=input, prompt=prompt):
-        return input
+    if __valid_text_input(input=user_input, prompt=prompt):
+        return user_input
 
     # Recursively Retry
     await asyncio.sleep(0.1)

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -229,10 +229,24 @@ async def __prompt_user_for_text_input(prompt: TextInputPromptRequest) -> str:
     # Print Prompt
     click.echo(italic(prompt.prompt))
 
-    # TODO: default value, placeholder.
+    # Display placeholder text if available
+    if prompt.placeholder_text:
+        click.echo(f"  Hint: {prompt.placeholder_text}")
+
+    # Display default value if available
+    prompt_suffix = ""
+    if prompt.default_value:
+        prompt_suffix = f" [default: {prompt.default_value}]"
+
+    click.echo(f"Enter value{prompt_suffix}: ", nl=False)
 
     # Wait for input async
     input = await aioconsole.ainput()
+
+    # Use default value if input is empty and default exists
+    if not input.strip() and prompt.default_value:
+        input = prompt.default_value
+        click.echo(f"Using default value: {input}")
 
     # validate input
     if __valid_text_input(input=input, prompt=prompt):


### PR DESCRIPTION
### What changed
Fixed text input prompts in the CLI to display placeholder_text and default_value fields that were being sent by the backend but not shown to users. 
  
### Related Issue
https://github.com/project-chip/certification-tool/issues/782

### Testing
Prompt displayed in CLI execution with the placeholder
 
<img width="1337" height="610" alt="Screenshot 2025-11-04 at 15 18 11" src="https://github.com/user-attachments/assets/fc97b9c1-b0b3-4fdf-9c3c-af0c58004f60" />
