### PR TITLE
[Fix] Handling Empty Usage Tag In CLI's PICS Parser

### DIFF
--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -341,9 +341,8 @@ def parse_pics_xml(xml_content: str) -> dict:
 
         # Parse usage items
         usage = root.find(".//usage")
-        if usage is not None:
-            usage_items = parse_pics_items(usage)
-            result["clusters"][cluster_name]["items"].update(usage_items)
+        if (usage := root.find(".//usage")) is not None:
+            result["clusters"][cluster_name]["items"].update(parse_pics_items(usage))
 
         # Parse server side items
         server_side = root.find(".//clusterSide[@type='Server']")

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -340,7 +340,6 @@ def parse_pics_xml(xml_content: str) -> dict:
         result = {"clusters": {cluster_name: {"name": cluster_name, "items": {}}}}
 
         # Parse usage items
-        usage = root.find(".//usage")
         if (usage := root.find(".//usage")) is not None:
             result["clusters"][cluster_name]["items"].update(parse_pics_items(usage))
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -340,8 +340,10 @@ def parse_pics_xml(xml_content: str) -> dict:
         result = {"clusters": {cluster_name: {"name": cluster_name, "items": {}}}}
 
         # Parse usage items
-        usage_items = parse_pics_items(root.find(".//usage"))
-        result["clusters"][cluster_name]["items"].update(usage_items)
+        usage = root.find(".//usage")
+        if usage is not None:
+            usage_items = parse_pics_items(usage)
+            result["clusters"][cluster_name]["items"].update(usage_items)
 
         # Parse server side items
         server_side = root.find(".//clusterSide[@type='Server']")


### PR DESCRIPTION
Fixes: https://github.com/project-chip/certification-tool/issues/803
---

The PICS parser logic was updated to verifying if the 'usage' tag exists, ignoring if not.
This avoid breaking the application when using, for instance, the `Base.xml` file as one of the PICS.

The example file is the following: [Base.xml](https://github.com/user-attachments/files/23729656/Base.xml)


Please refer to the Issue above for more information