### PR TITLE
Fix _send_prompt_response calls and added timeout for large upload

### DIFF
--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -289,7 +289,7 @@ async def __upload_file_and_send_response(
     try:
         if not os.path.isfile(file_path):
             click.echo(f"Error: File '{file_path}' does not exist or is not accessible", err=True)
-            await __send_prompt_response(socket=socket, input="", prompt=prompt)
+            await _send_prompt_response(socket=socket, input="", prompt=prompt)
             return
 
         file_size = os.path.getsize(file_path)
@@ -297,7 +297,7 @@ async def __upload_file_and_send_response(
         # Check file size limit
         if file_size > MAX_FILE_SIZE:
             click.echo(f"❌ File too large: {file_size} bytes (max: {MAX_FILE_SIZE} bytes)", err=True)
-            await __send_prompt_response(socket=socket, input="", prompt=prompt)
+            await _send_prompt_response(socket=socket, input="", prompt=prompt)
             return
 
         click.echo(f"File selected: {file_path} (size: {file_size:,} bytes)")
@@ -308,7 +308,9 @@ async def __upload_file_and_send_response(
             base_url = f"http://{base_url}"
         upload_url = f"{base_url}/api/v1/test_run_executions/file_upload/"
 
-        async with httpx.AsyncClient() as client:
+        # Set timeout to 5 minutes for large file uploads
+        timeout = httpx.Timeout(300.0, connect=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
             with open(file_path, "rb") as file:
                 files = {"file": (os.path.basename(file_path), file, "application/octet-stream")}
 
@@ -316,20 +318,20 @@ async def __upload_file_and_send_response(
 
                 if response.status_code == 200:
                     click.echo("✅ File uploaded successfully")
-                    await __send_prompt_response(socket=socket, input="SUCCESS", prompt=prompt)
+                    await _send_prompt_response(socket=socket, input="SUCCESS", prompt=prompt)
                 else:
                     click.echo(f"❌ File upload failed: {response.status_code} - {response.text}", err=True)
-                    await __send_prompt_response(socket=socket, input="", prompt=prompt)
+                    await _send_prompt_response(socket=socket, input="", prompt=prompt)
 
     except httpx.RequestError as e:
         click.echo(f"❌ Network error during file upload: {str(e)}", err=True)
-        await __send_prompt_response(socket=socket, input="", prompt=prompt)
+        await _send_prompt_response(socket=socket, input="", prompt=prompt)
     except httpx.HTTPStatusError as e:
         click.echo(f"❌ HTTP error during file upload: {e.response.status_code} - {e.response.text}", err=True)
-        await __send_prompt_response(socket=socket, input="", prompt=prompt)
+        await _send_prompt_response(socket=socket, input="", prompt=prompt)
     except Exception as e:
         click.echo(f"❌ Unexpected error uploading file: {str(e)}", err=True)
-        await __send_prompt_response(socket=socket, input="", prompt=prompt)
+        await _send_prompt_response(socket=socket, input="", prompt=prompt)
 
 
 def __valid_text_input(input: Any, prompt: TextInputPromptRequest) -> bool:

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -316,12 +316,9 @@ async def __upload_file_and_send_response(
 
                 response = await client.post(upload_url, files=files)
 
-                if response.status_code == 200:
-                    click.echo("✅ File uploaded successfully")
-                    await _send_prompt_response(socket=socket, input="SUCCESS", prompt=prompt)
-                else:
-                    click.echo(f"❌ File upload failed: {response.status_code} - {response.text}", err=True)
-                    await _send_prompt_response(socket=socket, input="", prompt=prompt)
+                response.raise_for_status()
+                click.echo("✅ File uploaded successfully")
+                await _send_prompt_response(socket=socket, input="SUCCESS", prompt=prompt)
 
     except httpx.RequestError as e:
         click.echo(f"❌ Network error during file upload: {str(e)}", err=True)

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -308,8 +308,8 @@ async def __upload_file_and_send_response(
             base_url = f"http://{base_url}"
         upload_url = f"{base_url}/api/v1/test_run_executions/file_upload/"
 
-        # Set timeout to 5 minutes for large file uploads
-        timeout = httpx.Timeout(300.0, connect=10.0)
+        # Set timeout for large file uploads
+        timeout = httpx.Timeout(UPLOAD_TIMEOUT_SECONDS, connect=CONNECT_TIMEOUT_SECONDS)
         async with httpx.AsyncClient(timeout=timeout) as client:
             with open(file_path, "rb") as file:
                 files = {"file": (os.path.basename(file_path), file, "application/octet-stream")}

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -41,7 +41,9 @@ from .socket_schemas import (
 )
 
 # Constants
-MAX_FILE_SIZE = 100 * 1024 * 1024  # 200MB in bytes
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB in bytes
+UPLOAD_TIMEOUT_SECONDS = 300.0
+CONNECT_TIMEOUT_SECONDS = 10.0
 
 # Global video handler instance for reuse
 _video_handler_instance = None


### PR DESCRIPTION
### What changed
The goal of this PR is to fix _send_prompt_response error, since the real method's name contains only one `_`, also it adds a timeout since the upload process may take a while.

### Related issue
https://github.com/project-chip/certification-tool/issues/804

### Testing
Run a test run execution that requires a file upload. The file is uploaded whiteout any errors.
<img width="1508" height="432" alt="Screenshot 2025-11-25 at 10 22 33" src="https://github.com/user-attachments/assets/a2d20ca0-d0c1-44ae-a46b-8973bf76de0d" />
