### PR TITLE
Fixing the CLI Run Test Logic to handle project config and user config

### DIFF
--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -721,8 +721,8 @@ class TestRunTestsCommand:
 
         # Assert
         assert result.exit_code == 0
-        assert "Read config from file" in result.output
-        assert "CLI Config for test run execution" in result.output
+        assert "Project Config" in result.output
+        assert "CLI Test Run Execution Config" in result.output
         # Should show the configuration data
         assert "dut_config" in result.output
         assert "network" in result.output

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -181,8 +181,11 @@ async def __project_config(
             project = await projects_api.read_project_api_v1_projects_id_get(id=project_id)
             return project.config
         except UnexpectedResponse as e:
-            """Ignore error retrieving project and return default configuration."""
-            pass
+            msg = (
+                f"Could not retrieve configuration for project ID '{project_id}': {e}"
+                "Falling back to default configuration."
+            )
+            click.echo(colorize_key_value("Warning:", msg))
 
     return await projects_api.default_config_api_v1_projects_default_config_get()
 

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -16,7 +16,6 @@
 import asyncio
 import datetime
 import json
-import os
 
 import click
 
@@ -34,7 +33,6 @@ from th_cli.colorize import (
     italic,
     set_colors_enabled,
 )
-from th_cli.config import get_package_root
 from th_cli.exceptions import CLIError, handle_api_error
 from th_cli.test_run.websocket import TestRunSocket
 from th_cli.utils import (
@@ -123,32 +121,21 @@ async def run_tests(
     try:
         client = get_client()
         async_apis = AsyncApis(client)
-        projects_api = async_apis.projects_api
         test_collections_api = async_apis.test_collections_api
 
         # Configure new log output for test.
         log_path = test_logging.configure_logger_for_run(title=title)
 
-        # Get default config and convert to dict
-        default_config = await projects_api.default_config_api_v1_projects_default_config_get()
-        default_config_dict = convert_nested_to_dict(default_config)
+        # Get project config and convert to dict
+        project_config = await __project_config(async_apis, project_id)
+        project_config_dict = convert_nested_to_dict(project_config)
+        click.echo(colorize_key_value("Project Config", project_config_dict))
 
-        # If config file is provided, read and parse it
-        if not config:
-            config = "default_config.properties"
-            # If default config not found in current directory, try package directory
-            if not os.path.exists(config):
-                # The config file is in the th_cli package directory
-                from pathlib import Path
-
-                package_config = Path(__file__).parent.parent / "default_config.properties"
-                if package_config.exists():
-                    config = str(package_config)
-
-        config_data = read_properties_file(config)
-        click.echo(colorize_key_value("Read config from file", config_data))
-        cli_config_dict = merge_properties_to_config(config_data, default_config_dict)
-        click.echo(colorize_key_value("CLI Config for test run execution", cli_config_dict))
+        # If config file is provided, read and merge into project config
+        if config:
+            config_data = read_properties_file(config)
+            project_config_dict = merge_properties_to_config(config_data, project_config_dict)
+            click.echo(colorize_key_value("CLI Test Run Execution Config", project_config_dict))
 
         # Read PICS configuration if provided
         pics = read_pics_config(pics_config_folder)
@@ -164,7 +151,7 @@ async def run_tests(
             async_apis,
             selected_tests=selected_tests_dict,
             title=title,
-            config=cli_config_dict,
+            config=project_config_dict,
             pics=pics,
             project_id=project_id,
         )
@@ -181,6 +168,23 @@ async def run_tests(
     finally:
         if client:
             await client.aclose()
+
+
+async def __project_config(
+    async_apis: AsyncApis, project_id: int | None = None
+) -> m.TestEnvironmentConfig:
+    """Retrieve project configuration for given project ID or default configuration if none provided."""
+    projects_api = async_apis.projects_api
+
+    if project_id is not None:
+        try:
+            project = await projects_api.read_project_api_v1_projects_id_get(id=project_id)
+            return project.config
+        except UnexpectedResponse as e:
+            """Ignore error retrieving project and return default configuration."""
+            pass
+
+    return await projects_api.default_config_api_v1_projects_default_config_get()
 
 
 async def __create_new_test_run_cli(

--- a/th_cli/config.py
+++ b/th_cli/config.py
@@ -22,13 +22,18 @@ from pydantic import BaseModel
 from th_cli.exceptions import CLIError
 
 
+def known_cli_path() -> Path:
+    """Return the known CLI path from the home directory."""
+    return Path(f"{Path.home()}/certification-tool/cli")
+
+
 def get_package_root() -> Path:
     """
     Get the root directory of the package installation.
     This works for both editable and non-editable installations.
     """
     # Get the directory containing this config.py file
-    return Path(__file__).parent.parent
+    return Path(__file__).parent
 
 
 def find_git_root() -> Path | None:
@@ -46,31 +51,14 @@ def find_git_root() -> Path | None:
         current_path = current_path.parent
 
     # If not found in package location, try current working directory
-    current_path = Path.cwd()
+    current_path = known_cli_path()
+
     while current_path != current_path.parent:
         if (current_path / ".git").exists():
             return current_path
         current_path = current_path.parent
 
     return None
-
-
-def is_editable_install() -> bool:
-    """
-    Detect if this is an editable installation.
-    """
-    package_root = get_package_root()
-    git_root = find_git_root()
-
-    # If git root and package root are the same, it's likely editable
-    if git_root and package_root:
-        try:
-            # Check if package root is within or same as git root
-            package_root.relative_to(git_root)
-            return True
-        except ValueError:
-            return False
-    return False
 
 
 def get_config_search_paths() -> list[Path]:
@@ -82,15 +70,12 @@ def get_config_search_paths() -> list[Path]:
     # Always include current working directory
     paths.append(Path.cwd())
 
+    # Include known CLI path in home directory
+    paths.append(known_cli_path())
+
     # Include package installation directory
     package_root = get_package_root()
     paths.append(package_root)
-
-    # If not editable install, also check git root (original source)
-    if not is_editable_install():
-        git_root = find_git_root()
-        if git_root and git_root != package_root:
-            paths.append(git_root)
 
     return paths
 

--- a/th_cli/config.py
+++ b/th_cli/config.py
@@ -24,7 +24,7 @@ from th_cli.exceptions import CLIError
 
 def known_cli_path() -> Path:
     """Return the known CLI path from the home directory."""
-    return Path(f"{Path.home()}/certification-tool/cli")
+    return Path.home() / "certification-tool" / "cli"
 
 
 def get_package_root() -> Path:


### PR DESCRIPTION
Related to: https://github.com/project-chip/certification-tool/issues/816
Related to: https://github.com/project-chip/certification-tool-backend/pull/283
---

# Description

Fixing CLI `run_tests()` logic to retrieve and use the configuration from the TH project, in case project-id is provided, returning default otherwise.
CLI will print only the project config to the output, unless the config is provided as well in the `run-tests()` command.

Also, one Unit Test was updated accordingly.

Finally, the CLI config.py file was updated to use a known path for the project as well, to reduce complexity and work for either --editable mode and default `th-cli` application.