### PR TITLE
[Feature] Adding the Node ID to CLI Output

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -763,6 +763,28 @@
                 }
             }
         },
+        "/api/v1/test_run_executions/chip-server/info": {
+            "get": {
+                "tags": [
+                    "test_run_executions"
+                ],
+                "summary": "Get Chip Server Info",
+                "description": "Retrieve ChipServer node ID information.\n\nReturns:\n    ChipServerInfo: Contains node_id (int) and node_id_hex (str) values.",
+                "operationId": "get_chip_server_info_api_v1_test_run_executions_chip_server_info_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChipServerInfo"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/test_run_executions/status": {
             "get": {
                 "tags": [
@@ -1434,6 +1456,25 @@
                         "format": "binary"
                     }
                 }
+            },
+            "ChipServerInfo": {
+                "title": "ChipServerInfo",
+                "required": [
+                    "node_id",
+                    "node_id_hex"
+                ],
+                "type": "object",
+                "properties": {
+                    "node_id": {
+                        "title": "Node Id",
+                        "type": "integer"
+                    },
+                    "node_id_hex": {
+                        "title": "Node Id Hex",
+                        "type": "string"
+                    }
+                },
+                "description": "Schema for ChipServer information."
             },
             "DutConfig": {
                 "title": "DutConfig",

--- a/th_cli/api_lib_autogen/api/test_run_executions_api.py
+++ b/th_cli/api_lib_autogen/api/test_run_executions_api.py
@@ -114,6 +114,18 @@ class _TestRunExecutionsApi:
             url="/api/v1/test_run_executions/status",
         )
 
+    def _build_for_get_chip_server_info_api_v1_test_run_executions_chip_server_info_get(
+        self,
+    ) -> Awaitable[m.ChipServerInfo]:
+        """
+        Retrieve ChipServer node information.
+        """
+        return self.api_client.request(
+            type_=m.ChipServerInfo,
+            method="GET",
+            url="/api/v1/test_run_executions/chip-server/info",
+        )
+
     def _build_for_read_test_run_execution_api_v1_test_run_executions_id_get(
         self, id: int
     ) -> Awaitable[m.TestRunExecutionWithChildren]:
@@ -271,6 +283,14 @@ class AsyncTestRunExecutionsApi(_TestRunExecutionsApi):
         Retrieve status of the Test Engine.  When the Test Engine is actively running the status will include the current test_run and the details of the states.
         """
         return await self._build_for_get_test_runner_status_api_v1_test_run_executions_status_get()
+
+    async def get_chip_server_info_api_v1_test_run_executions_chip_server_info_get(
+        self,
+    ) -> m.ChipServerInfo:
+        """
+        Retrieve ChipServer node information.
+        """
+        return await self._build_for_get_chip_server_info_api_v1_test_run_executions_chip_server_info_get()
 
     async def read_test_run_execution_api_v1_test_run_executions_id_get(
         self, id: int

--- a/th_cli/api_lib_autogen/models.py
+++ b/th_cli/api_lib_autogen/models.py
@@ -230,6 +230,11 @@ class TestRunnerStatus(BaseModel):
     test_run_execution_id: "Optional[int]" = Field(None, alias="test_run_execution_id")
 
 
+class ChipServerInfo(BaseModel):
+    node_id: "str" = Field(..., alias="node_id")
+    node_id_hex: "str" = Field(..., alias="node_id_hex")
+
+
 class TestStepExecution(BaseModel):
     state: "TestStateEnum" = Field(..., alias="state")
     title: "str" = Field(..., alias="title")

--- a/th_cli/api_lib_autogen/models.py
+++ b/th_cli/api_lib_autogen/models.py
@@ -231,7 +231,7 @@ class TestRunnerStatus(BaseModel):
 
 
 class ChipServerInfo(BaseModel):
-    node_id: "str" = Field(..., alias="node_id")
+    node_id: "int" = Field(..., alias="node_id")
     node_id_hex: "str" = Field(..., alias="node_id_hex")
 
 

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -217,6 +217,7 @@ async def __create_new_test_run_cli(
 async def __start_test_run(
     async_apis: AsyncApis, test_run: m.TestRunExecutionWithChildren
 ) -> m.TestRunExecutionWithChildren:
+    test_run_executions_api = async_apis.test_run_executions_api
     header = colorize_header("Starting Test run")
     title = colorize_key_value("Title", test_run.title)
     id = colorize_key_value("ID", str(test_run.id))
@@ -226,16 +227,14 @@ async def __start_test_run(
 
     # Fetch and display ChipServer node ID information
     try:
-        test_run_executions_api = async_apis.test_run_executions_api
         chip_info = await test_run_executions_api.get_chip_server_info_api_v1_test_run_executions_chip_server_info_get()
-        node_id_hex = colorize_key_value("Node ID (Hex)", chip_info.node_id_hex)
+        node_id_hex = colorize_key_value("Node ID", chip_info.node_id_hex)
         click.echo(f"- {node_id_hex}\n")
-    except Exception as e:
+    except UnexpectedResponse as e:
         # If we can't fetch node_id, don't fail - just skip displaying it
-        click.echo(f"Could not fetch ChipServer node ID information: {e}")
+        click.echo(f"Could not fetch ChipServer node ID information: {e}\n")
 
     try:
-        test_run_executions_api = async_apis.test_run_executions_api
         return await test_run_executions_api.start_test_run_execution_api_v1_test_run_executions_id_start_post(
             id=test_run.id
         )

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -222,7 +222,17 @@ async def __start_test_run(
     id = colorize_key_value("ID", str(test_run.id))
 
     click.echo("")
-    click.echo(f"{header}:\n- {title}\n- {id}\n")
+    click.echo(f"{header}:\n- {title}\n- {id}")
+
+    # Fetch and display ChipServer node ID information
+    try:
+        test_run_executions_api = async_apis.test_run_executions_api
+        chip_info = await test_run_executions_api.get_chip_server_info_api_v1_test_run_executions_chip_server_info_get()
+        node_id_hex = colorize_key_value("Node ID (Hex)", chip_info.node_id_hex)
+        click.echo(f"- {node_id_hex}\n")
+    except Exception as e:
+        # If we can't fetch node_id, don't fail - just skip displaying it
+        click.echo(f"Could not fetch ChipServer node ID information: {e}")
 
     try:
         test_run_executions_api = async_apis.test_run_executions_api


### PR DESCRIPTION
Related to: https://github.com/project-chip/certification-tool/issues/802
Related to: https://github.com/project-chip/certification-tool-backend/pull/284
---

Printing the Node ID information from the CHIP-server to the CLI Output.
This information is particularly useful for some CLI test run executions e currently is being retrieved from the th-sdk docker container as a workaround.
