### PR TITLE
Enhanced the th-cli available-tests command with new formatting options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,14 @@ def sample_test_collections() -> api_models.TestCollections:
                                     title="Test Case ACE 1.2",
                                     description="Access Control Entry test 2"
                                 )
+                            ),
+                            "TC-CC-1.1": api_models.TestCase(
+                                metadata=api_models.TestMetadata(
+                                    public_id="TC-CC-1.1",
+                                    version="1.0",
+                                    title="Test Case CC 1.1",
+                                    description="Color Control test"
+                                )
                             )
                         }
                     )

--- a/tests/test_available_tests.py
+++ b/tests/test_available_tests.py
@@ -342,3 +342,341 @@ class TestAvailableTestsCommand:
         assert "  SDK YAML Tests:" in result.output or "SDK YAML Tests:" in result.output
         # Should not contain JSON-specific formatting
         assert '"test_collections":' not in result.output
+
+    def test_available_tests_compact(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --compact flag shows test IDs with titles."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Act
+            result = cli_runner.invoke(available_tests, ["--compact"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should contain test IDs with compact format (IDs only)
+        assert "TC-ACE-1.1" in result.output
+        assert "TC-ACE-1.2" in result.output
+        assert "TC-CC-1.1" in result.output
+        # Should not contain full YAML/JSON structure
+        assert "test_collections:" not in result.output
+
+    def test_available_tests_group_by_cluster(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --group-by-cluster flag groups tests by cluster."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Act
+            result = cli_runner.invoke(available_tests, ["--group-by-cluster"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should contain cluster headers
+        assert "ACE:" in result.output
+        assert "CC:" in result.output
+        # Should contain separator lines
+        assert "----" in result.output or "---" in result.output
+        # Should contain indented test cases under clusters
+        assert "  TC-ACE-1.1" in result.output
+        assert "  TC-CC-1.1" in result.output
+
+    def test_available_tests_cluster_filter(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --cluster filter shows only tests from specified cluster."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Act
+            result = cli_runner.invoke(available_tests, ["--cluster", "ACE"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should contain only ACE tests in detailed format
+        assert "Test Cases for Cluster: ACE" in result.output
+        assert "ID: TC-ACE-1.1" in result.output
+        assert "ID: TC-ACE-1.2" in result.output
+        # Should not contain CC tests
+        assert "TC-CC-1.1" not in result.output
+
+    def test_available_tests_cluster_filter_case_insensitive(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --cluster filter is case insensitive."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Act
+            result = cli_runner.invoke(available_tests, ["--cluster", "ace"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should contain ACE tests in detailed format even with lowercase input
+        assert "Test Cases for Cluster: ACE" in result.output
+        assert "ID: TC-ACE-1.1" in result.output
+        assert "ID: TC-ACE-1.2" in result.output
+
+    def test_available_tests_cluster_and_compact_combined(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test combining --cluster and --compact flags."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Act
+            result = cli_runner.invoke(available_tests, ["--cluster", "CC", "--compact"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should contain only CC tests in compact format (IDs only)
+        assert "TC-CC-1.1" in result.output
+        # Should not contain ACE tests
+        assert "TC-ACE-1.1" not in result.output
+
+    def test_extract_cluster_from_test_id(self) -> None:
+        """Test cluster extraction logic for various test ID patterns."""
+        from th_cli.commands.available_tests import _extract_cluster_from_test_id
+
+        # Test various patterns
+        assert _extract_cluster_from_test_id("TC-ACE-1.1") == "ACE"
+        assert _extract_cluster_from_test_id("TC-CADMIN-1.2") == "CADMIN"
+        assert _extract_cluster_from_test_id("Test_TC_CC_1_1") == "CC"
+        assert _extract_cluster_from_test_id("TC_WEBRTC_1_6") == "WEBRTC"
+        assert _extract_cluster_from_test_id("TC_WEBRTCP_1_8") == "WEBRTCP"
+        assert _extract_cluster_from_test_id("TC_WEBRTC-1.2") == "WEBRTC"
+        assert _extract_cluster_from_test_id("TC_WEBRTCP-4.2") == "WEBRTCP"
+        assert _extract_cluster_from_test_id("TC_AUDIO_1_6") == "AUDIO"
+
+        # Test edge cases from real data
+        assert _extract_cluster_from_test_id("TC_ACE_1_3-custom") == "ACE"
+        assert _extract_cluster_from_test_id("TC_ACE_1_3_R-custom") == "ACE"
+        assert _extract_cluster_from_test_id("TC_MCORE_FS_1_1") == "MCOREFS"
+        assert _extract_cluster_from_test_id("TC_WebRTCP_2_1") == "WEBRTCP"
+        assert _extract_cluster_from_test_id("TC_WebRTCR_2_1") == "WEBRTCR"
+        assert _extract_cluster_from_test_id("TC-APPLAUNCHER-3.5") == "APPLAUNCHER"
+        assert _extract_cluster_from_test_id("TC-CONTENTLAUNCHER-10.1") == "CONTENTLAUNCHER"
+
+        assert _extract_cluster_from_test_id("SomeOtherTest") == "UNKNOWN"
+
+    def test_generate_compact(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test _generate_compact function with 4 elements per line."""
+        from th_cli.commands.available_tests import _extract_test_cases, _generate_compact
+
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Extract test cases
+            test_cases = _extract_test_cases(sample_test_collections)
+
+            # Act
+            result_lines = _generate_compact(test_cases)
+
+        # Assert
+        # Should have fewer lines since we put 4 elements per line
+        assert len(result_lines) <= len(test_cases)
+        # Each line should contain test case IDs
+        for line in result_lines:
+            # Lines should contain test case IDs
+            assert "TC-" in line or "TC_" in line  # Support different formats
+        # First line should contain first test case ID only
+        assert any("TC-ACE-1.1" in line for line in result_lines)
+
+    def test_generate_grouped_by_cluster(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test _generate_grouped_by_cluster function with 4 elements per line."""
+        from th_cli.commands.available_tests import _extract_test_cases, _generate_grouped_by_cluster
+
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            # Extract test cases
+            test_cases = _extract_test_cases(sample_test_collections)
+
+            # Act
+            result_lines = _generate_grouped_by_cluster(test_cases)
+
+        # Assert
+        result_text = '\n'.join(result_lines)
+        assert "ACE:" in result_text
+        assert "CC:" in result_text
+        # Check that tests within clusters use uniform spacing format
+        ace_line_found = False
+        for line in result_lines:
+            # Look for lines with multiple ACE tests using double space separator
+            if "TC-ACE" in line and "  " in line:
+                ace_line_found = True
+                break
+        # Should find at least one line with multiple ACE tests
+        assert ace_line_found or len([tc for tc in test_cases if tc['cluster'] == 'ACE']) < 4
+
+    def test_available_tests_compact_four_per_line(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --compact flag shows 4 elements per line."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            with patch("click.echo_via_pager") as mock_pager:
+                # Act
+                result = cli_runner.invoke(available_tests, ["--compact"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should have called echo_via_pager
+        mock_pager.assert_called_once()
+        # Check that content contains spacing for multiple elements
+        call_content = mock_pager.call_args[0][0]  # First argument (content)
+        # Should contain test cases with uniform spacing (using double spaces)
+        lines = call_content.split('\n')
+        uniform_spacing_found = any("  " in line and "TC-" in line for line in lines)
+        assert uniform_spacing_found or call_content.count('\n') == 0  # Exception for small datasets
+
+    def test_available_tests_group_by_cluster_four_per_line(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --group-by-cluster flag shows 4 elements per line within clusters."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            with patch("click.echo_via_pager") as mock_pager:
+                # Act
+                result = cli_runner.invoke(available_tests, ["--group-by-cluster"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should have called echo_via_pager
+        mock_pager.assert_called_once()
+        # Check that content includes cluster headers and organized content
+        call_content = mock_pager.call_args[0][0]  # First argument (content)
+        assert "ACE:" in call_content
+        assert "CC:" in call_content
+
+    def test_available_tests_with_pagination_mock(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test available_tests command uses echo_via_pager."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            with patch("click.echo_via_pager") as mock_pager:
+                # Act
+                result = cli_runner.invoke(available_tests, ["--compact"])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should have called echo_via_pager
+        mock_pager.assert_called_once()
+        # Check that correct content was passed to pager
+        call_content = mock_pager.call_args[0][0]  # First argument (content)
+        assert "TC-ACE-1.1" in call_content
+        assert "TC-ACE-1.2" in call_content
+        assert "TC-CC-1.1" in call_content
+
+    def test_available_tests_echo_via_pager_behavior(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test that echo_via_pager is called for all custom formatting options."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            with patch("click.echo_via_pager") as mock_pager:
+                # Test different formatting options
+                for args in [["--compact"], ["--group-by-cluster"], []]:
+                    mock_pager.reset_mock()
+                    # Act
+                    result = cli_runner.invoke(available_tests, args)
+
+                    # Assert
+                    assert result.exit_code == 0
+                    mock_pager.assert_called_once()
+
+    def test_available_tests_cluster_detailed_info(
+        self,
+        cli_runner: CliRunner,
+        mock_sync_apis: Mock,
+        sample_test_collections: api_models.TestCollections
+    ) -> None:
+        """Test --cluster flag shows detailed information."""
+        # Arrange
+        api = mock_sync_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        api.return_value = sample_test_collections
+
+        with patch("th_cli.commands.available_tests.SyncApis", return_value=mock_sync_apis):
+            with patch("click.echo_via_pager") as mock_pager:
+                # Act
+                result = cli_runner.invoke(available_tests, ["--cluster", "ACE"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_pager.assert_called_once()
+        # Check that detailed content is displayed
+        call_content = mock_pager.call_args[0][0]  # First argument (content)
+        assert "Test Cases for Cluster: ACE" in call_content
+        assert "ID:" in call_content
+        assert "Title:" in call_content
+        assert "Description:" in call_content
+        assert "Collection:" in call_content
+        assert "Suite:" in call_content
+        assert "Total test cases found:" in call_content
+

--- a/tests/test_available_tests.py
+++ b/tests/test_available_tests.py
@@ -679,4 +679,3 @@ class TestAvailableTestsCommand:
         assert "Collection:" in call_content
         assert "Suite:" in call_content
         assert "Total test cases found:" in call_content
-

--- a/th_cli/commands/available_tests.py
+++ b/th_cli/commands/available_tests.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import re
-from collections import defaultdict
 from typing import Any, Dict, List, Optional
+import re
+import textwrap
+from collections import defaultdict
 
 import click
 import yaml
@@ -29,6 +30,27 @@ from th_cli.utils import __json_string, __print_json
 
 # Constants
 COLUMN_WIDTH = 23  # Fixed width for test ID columns with proper spacing
+
+
+def _format_test_ids_line(test_ids: List[str]) -> str:
+    """Format a list of test IDs into a padded, columnar line with 4 elements per line."""
+    line_parts = []
+
+    for j, test_id in enumerate(test_ids):
+        if j < len(test_ids) - 1:  # Not the last element in the line
+            # Pad to COLUMN_WIDTH for uniform spacing
+            if len(test_id) > COLUMN_WIDTH:
+                # If the ID is too long, truncate
+                padded = test_id[:COLUMN_WIDTH]
+            else:
+                padded = test_id.ljust(COLUMN_WIDTH)
+            line_parts.append(padded)
+        else:
+            # Last element doesn't need padding
+            line_parts.append(test_id)
+
+    # Join with minimal spacing
+    return "  ".join(line_parts)
 
 
 @click.command(
@@ -90,9 +112,6 @@ def available_tests(
             elif cluster:
                 # When filtering by cluster, show detailed information
                 content_lines = _generate_detailed_cluster_info(test_cases, cluster)
-            else:
-                # Default to compact format for any custom formatting
-                content_lines = _generate_compact(test_cases)
 
             # Display with Click's echo_via_pager
             content = "\n".join(content_lines)
@@ -134,23 +153,7 @@ def _generate_compact(test_cases: List[Dict[str, str]]) -> List[str]:
     # Process in batches of 4
     for i in range(0, len(test_ids), 4):
         batch = test_ids[i : i + 4]
-        line_parts = []
-
-        for j, test_id in enumerate(batch):
-            if j < len(batch) - 1:  # Not the last element in the line
-                # Pad to COLUMN_WIDTH for uniform spacing
-                if len(test_id) > COLUMN_WIDTH:
-                    # If the ID is too long, truncate
-                    padded = test_id[:COLUMN_WIDTH]
-                else:
-                    padded = test_id.ljust(COLUMN_WIDTH)
-                line_parts.append(padded)
-            else:
-                # Last element doesn't need padding
-                line_parts.append(test_id)
-
-        # Join with minimal spacing
-        lines.append("  ".join(line_parts))
+        lines.append(_format_test_ids_line(batch))
 
     return lines
 
@@ -173,24 +176,10 @@ def _generate_grouped_by_cluster(test_cases: List[Dict[str, str]]) -> List[str]:
         cluster_tests = sorted(clusters[cluster_name], key=lambda x: x["id"])
         for i in range(0, len(cluster_tests), 4):
             batch = cluster_tests[i : i + 4]
-            line_parts = []
+            test_ids_batch = [test_case["id"] for test_case in batch]
 
-            for j, test_case in enumerate(batch):
-                test_id = test_case["id"]
-                if j < len(batch) - 1:  # Not the last element in the line
-                    # Pad to COLUMN_WIDTH for uniform spacing
-                    if len(test_id) > COLUMN_WIDTH:
-                        # If the ID is too long, truncate
-                        padded = test_id[:COLUMN_WIDTH]
-                    else:
-                        padded = test_id.ljust(COLUMN_WIDTH)
-                    line_parts.append(padded)
-                else:
-                    # Last element doesn't need padding
-                    line_parts.append(test_id)
-
-            # Add indentation and join with minimal spacing
-            lines.append("  " + "  ".join(line_parts))
+            # Add indentation to the formatted line
+            lines.append("  " + _format_test_ids_line(test_ids_batch))
 
     return lines
 
@@ -209,21 +198,14 @@ def _generate_detailed_cluster_info(test_cases: List[Dict[str, str]], cluster_na
         lines.append(f"ID: {test_case['id']}")
         lines.append(f"Title: {test_case['title']}")
         if "description" in test_case and test_case["description"]:
-            # Wrap long descriptions
             description = test_case["description"]
-            if len(description) > 80:
-                # Break description into lines of 80 characters
-                words = description.split()
-                current_line = "Description: "
-                for word in words:
-                    if len(current_line) + len(word) + 1 <= 80:
-                        current_line += word + " "
-                    else:
-                        lines.append(current_line.rstrip())
-                        current_line = "             " + word + " "  # Indent continuation
-                lines.append(current_line.rstrip())
-            else:
-                lines.append(f"Description: {description}")
+            description_lines = textwrap.wrap(
+                description,
+                width=80,
+                initial_indent="Description: ",
+                subsequent_indent="             ",
+            )
+            lines.extend(description_lines)
         lines.append(f"Collection: {test_case['collection']}")
         lines.append(f"Suite: {test_case['suite']}")
         lines.append("-" * 60)
@@ -275,10 +257,6 @@ def _extract_cluster_from_test_id(test_id: str) -> str:
         # Pattern 4: TC_CLUSTER_numbers (underscore separated)
         # Handle mixed case clusters (like WebRTCP, WebRTCR, MCORE_FS)
         r"^TC_([A-Za-z_]+?)_\d+",  # Mixed case clusters with underscores
-        # Pattern 5: TC_CLUSTER_numbers (all uppercase, underscore separated)
-        # Special handling for clusters that end with TC or TCP (like WEBRTC, WEBRTCP)
-        r"^TC_([A-Z]*TCP?)_\d+",  # Matches clusters ending in TC or TCP first
-        r"^TC_([A-Z]+)_\d+",  # Then regular clusters
     ]
 
     for pattern in patterns:

--- a/th_cli/commands/available_tests.py
+++ b/th_cli/commands/available_tests.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Dict, List, Optional
 import re
 from collections import defaultdict
+from typing import Any, Dict, List, Optional
 
 import click
 import yaml
@@ -57,10 +57,7 @@ from th_cli.utils import __json_string, __print_json
     help=colorize_help("Group test cases by cluster, 4 per line"),
 )
 def available_tests(
-    json: bool = False,
-    compact: bool = False,
-    cluster: Optional[str] = None,
-    group_by_cluster: bool = False
+    json: bool = False, compact: bool = False, cluster: Optional[str] = None, group_by_cluster: bool = False
 ) -> None:
     """Get a list of the available test cases"""
     client = None
@@ -95,7 +92,7 @@ def available_tests(
                 content_lines = _generate_compact(test_cases)
 
             # Display with Click's echo_via_pager
-            content = '\n'.join(content_lines)
+            content = "\n".join(content_lines)
             click.echo_via_pager(content)
         else:
             # Original behavior - full output (YAML or JSON) with pagination
@@ -132,11 +129,11 @@ def _generate_compact(test_cases: List[Dict[str, str]]) -> List[str]:
     column_width = 23  # Increased from 18 to 23 (added 5 spaces)
 
     # Extract only the IDs
-    test_ids = [test_case['id'] for test_case in test_cases]
+    test_ids = [test_case["id"] for test_case in test_cases]
 
     # Process in batches of 4
     for i in range(0, len(test_ids), 4):
-        batch = test_ids[i:i+4]
+        batch = test_ids[i : i + 4]
         line_parts = []
 
         for j, test_id in enumerate(batch):
@@ -165,7 +162,7 @@ def _generate_grouped_by_cluster(test_cases: List[Dict[str, str]]) -> List[str]:
     # Group by cluster
     clusters = defaultdict(list)
     for test_case in test_cases:
-        clusters[test_case['cluster']].append(test_case)
+        clusters[test_case["cluster"]].append(test_case)
 
     # Use a larger fixed width for IDs with more spacing between columns
     column_width = 23  # Increased from 18 to 23 (added 5 spaces)
@@ -176,13 +173,13 @@ def _generate_grouped_by_cluster(test_cases: List[Dict[str, str]]) -> List[str]:
         lines.append("-" * (len(cluster_name) + 1))
 
         # Group tests in this cluster by 4 per line with compact spacing
-        cluster_tests = sorted(clusters[cluster_name], key=lambda x: x['id'])
+        cluster_tests = sorted(clusters[cluster_name], key=lambda x: x["id"])
         for i in range(0, len(cluster_tests), 4):
-            batch = cluster_tests[i:i+4]
+            batch = cluster_tests[i : i + 4]
             line_parts = []
 
             for j, test_case in enumerate(batch):
-                test_id = test_case['id']
+                test_id = test_case["id"]
                 if j < len(batch) - 1:  # Not the last element in the line
                     # Pad to column_width for uniform spacing
                     if len(test_id) > column_width:
@@ -214,9 +211,9 @@ def _generate_detailed_cluster_info(test_cases: List[Dict[str, str]], cluster_na
     for test_case in test_cases:
         lines.append(f"ID: {test_case['id']}")
         lines.append(f"Title: {test_case['title']}")
-        if 'description' in test_case and test_case['description']:
+        if "description" in test_case and test_case["description"]:
             # Wrap long descriptions
-            description = test_case['description']
+            description = test_case["description"]
             if len(description) > 80:
                 # Break description into lines of 80 characters
                 words = description.split()
@@ -247,16 +244,16 @@ def _extract_test_cases(test_collections: Any) -> List[Dict[str, str]]:
         for suite_name, suite in collection.test_suites.items():
             for test_case_id, test_case in suite.test_cases.items():
                 test_info = {
-                    'id': test_case.metadata.public_id,
-                    'title': test_case.metadata.title,
-                    'description': test_case.metadata.description if hasattr(test_case.metadata, 'description') else '',
-                    'collection': collection_name,
-                    'suite': suite_name,
-                    'cluster': _extract_cluster_from_test_id(test_case.metadata.public_id)
+                    "id": test_case.metadata.public_id,
+                    "title": test_case.metadata.title,
+                    "description": test_case.metadata.description if hasattr(test_case.metadata, "description") else "",
+                    "collection": collection_name,
+                    "suite": suite_name,
+                    "cluster": _extract_cluster_from_test_id(test_case.metadata.public_id),
                 }
                 test_cases.append(test_info)
 
-    return sorted(test_cases, key=lambda x: x['id'])
+    return sorted(test_cases, key=lambda x: x["id"])
 
 
 def _extract_cluster_from_test_id(test_id: str) -> str:
@@ -271,24 +268,20 @@ def _extract_cluster_from_test_id(test_id: str) -> str:
 
     patterns = [
         # Pattern 1: TC-CLUSTER-numbers (dash separated)
-        r'^TC-([A-Z]+)-[\d.]+',
-
+        r"^TC-([A-Z]+)-[\d.]+",
         # Pattern 2: Test_TC_CLUSTER_numbers (underscore separated with Test_ prefix)
-        r'^Test_TC_([A-Z]+)_[\d_]+',
-
+        r"^Test_TC_([A-Z]+)_[\d_]+",
         # Pattern 3: TC_CLUSTER-numbers (mixed underscore/dash format)
         # Special handling for clusters that end with TC or TCP (like WEBRTC, WEBRTCP)
-        r'^TC_([A-Z]*TCP?)-[\d.]+',  # Matches clusters ending in TC or TCP first
-        r'^TC_([A-Z]+)-[\d.]+',      # Then regular clusters with dash
-
+        r"^TC_([A-Z]*TCP?)-[\d.]+",  # Matches clusters ending in TC or TCP first
+        r"^TC_([A-Z]+)-[\d.]+",  # Then regular clusters with dash
         # Pattern 4: TC_CLUSTER_numbers (underscore separated)
         # Handle mixed case clusters (like WebRTCP, WebRTCR, MCORE_FS)
-        r'^TC_([A-Za-z_]+?)_\d+',    # Mixed case clusters with underscores
-
+        r"^TC_([A-Za-z_]+?)_\d+",  # Mixed case clusters with underscores
         # Pattern 5: TC_CLUSTER_numbers (all uppercase, underscore separated)
         # Special handling for clusters that end with TC or TCP (like WEBRTC, WEBRTCP)
-        r'^TC_([A-Z]*TCP?)_\d+',     # Matches clusters ending in TC or TCP first
-        r'^TC_([A-Z]+)_\d+'          # Then regular clusters
+        r"^TC_([A-Z]*TCP?)_\d+",  # Matches clusters ending in TC or TCP first
+        r"^TC_([A-Z]+)_\d+",  # Then regular clusters
     ]
 
     for pattern in patterns:
@@ -296,20 +289,20 @@ def _extract_cluster_from_test_id(test_id: str) -> str:
         if match:
             cluster = match.group(1)
             # Convert to uppercase and replace underscores if needed
-            if '_' in cluster or any(c.islower() for c in cluster):
+            if "_" in cluster or any(c.islower() for c in cluster):
                 # For mixed case or underscore clusters, convert appropriately
-                cluster = cluster.upper().replace('_', '')
+                cluster = cluster.upper().replace("_", "")
             return cluster
 
     # Final fallback: extract any sequence of uppercase letters
-    match = re.search(r'([A-Z]{2,})', test_id)
+    match = re.search(r"([A-Z]{2,})", test_id)
     if match:
         return match.group(1)
 
-    return 'UNKNOWN'
+    return "UNKNOWN"
 
 
 def _filter_by_cluster(test_cases: List[Dict[str, str]], cluster: str) -> List[Dict[str, str]]:
     """Filter test cases by cluster name (case insensitive)."""
     cluster_upper = cluster.upper()
-    return [tc for tc in test_cases if tc['cluster'].upper() == cluster_upper]
+    return [tc for tc in test_cases if tc["cluster"].upper() == cluster_upper]

--- a/th_cli/commands/available_tests.py
+++ b/th_cli/commands/available_tests.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any
+from typing import Any, Dict, List, Optional
+import re
+from collections import defaultdict
 
 import click
 import yaml
@@ -36,7 +38,30 @@ from th_cli.utils import __json_string, __print_json
     default=False,
     help=colorize_help("Print JSON response for more details"),
 )
-def available_tests(json: bool = False) -> None:
+@click.option(
+    "--compact",
+    is_flag=True,
+    default=False,
+    help=colorize_help("Show test IDs only, 4 per line"),
+)
+@click.option(
+    "--cluster",
+    type=str,
+    required=False,
+    help=colorize_help("Filter by cluster name (e.g., ACE, CADMIN, CC)"),
+)
+@click.option(
+    "--group-by-cluster",
+    is_flag=True,
+    default=False,
+    help=colorize_help("Group test cases by cluster, 4 per line"),
+)
+def available_tests(
+    json: bool = False,
+    compact: bool = False,
+    cluster: Optional[str] = None,
+    group_by_cluster: bool = False
+) -> None:
     """Get a list of the available test cases"""
     client = None
     try:
@@ -47,10 +72,42 @@ def available_tests(json: bool = False) -> None:
         if test_collections is None:
             raise CLIError("Server did not return test_collection")
 
-        if json:
-            __print_json(test_collections)
+        # Check if any custom formatting options are used
+        has_custom_formatting = compact or cluster or group_by_cluster
+
+        if has_custom_formatting:
+            test_cases = _extract_test_cases(test_collections)
+
+            # Filter by cluster if specified
+            if cluster:
+                test_cases = _filter_by_cluster(test_cases, cluster)
+
+            # Generate content based on formatting option
+            if group_by_cluster:
+                content_lines = _generate_grouped_by_cluster(test_cases)
+            elif compact:
+                content_lines = _generate_compact(test_cases)
+            elif cluster:
+                # When filtering by cluster, show detailed information
+                content_lines = _generate_detailed_cluster_info(test_cases, cluster)
+            else:
+                # Default to compact format for any custom formatting
+                content_lines = _generate_compact(test_cases)
+
+            # Display with Click's echo_via_pager
+            content = '\n'.join(content_lines)
+            click.echo_via_pager(content)
         else:
-            __print_yaml(test_collections)
+            # Original behavior - full output (YAML or JSON) with pagination
+            if json:
+                content = __json_string(test_collections)
+            else:
+                yaml_dump = yaml.dump(yaml.load(__json_string(test_collections), Loader=yaml.FullLoader))
+                # Don't use colorize_dump since echo_via_pager strips colors anyway
+                content = yaml_dump
+
+            # Display with Click's echo_via_pager for pagination
+            click.echo_via_pager(content)
     except CLIError:
         raise  # Re-raise CLI Errors as-is
     except UnexpectedResponse as e:
@@ -64,6 +121,195 @@ def available_tests(json: bool = False) -> None:
             client.close()
 
 
-def __print_yaml(object: Any) -> None:
-    yaml_dump = yaml.dump(yaml.load(__json_string(object), Loader=yaml.FullLoader))
-    click.echo(colorize_dump(yaml_dump))
+def _generate_compact(test_cases: List[Dict[str, str]]) -> List[str]:
+    """Generate test cases in compact format with only IDs, 4 per line with compact spacing."""
+    if not test_cases:
+        return []
+
+    lines = []
+
+    # Use a larger fixed width for IDs with more spacing between columns
+    column_width = 23  # Increased from 18 to 23 (added 5 spaces)
+
+    # Extract only the IDs
+    test_ids = [test_case['id'] for test_case in test_cases]
+
+    # Process in batches of 4
+    for i in range(0, len(test_ids), 4):
+        batch = test_ids[i:i+4]
+        line_parts = []
+
+        for j, test_id in enumerate(batch):
+            if j < len(batch) - 1:  # Not the last element in the line
+                # Pad to column_width for uniform spacing
+                if len(test_id) > column_width:
+                    # If the ID is too long, truncate
+                    padded = test_id[:column_width]
+                else:
+                    padded = test_id.ljust(column_width)
+                line_parts.append(padded)
+            else:
+                # Last element doesn't need padding
+                line_parts.append(test_id)
+
+        # Join with minimal spacing
+        lines.append("  ".join(line_parts))
+
+    return lines
+
+
+def _generate_grouped_by_cluster(test_cases: List[Dict[str, str]]) -> List[str]:
+    """Generate test cases grouped by cluster, 4 per line with only IDs and compact spacing."""
+    lines = []
+
+    # Group by cluster
+    clusters = defaultdict(list)
+    for test_case in test_cases:
+        clusters[test_case['cluster']].append(test_case)
+
+    # Use a larger fixed width for IDs with more spacing between columns
+    column_width = 23  # Increased from 18 to 23 (added 5 spaces)
+
+    # Generate lines for each cluster
+    for cluster_name in sorted(clusters.keys()):
+        lines.append(f"\n{cluster_name}:")
+        lines.append("-" * (len(cluster_name) + 1))
+
+        # Group tests in this cluster by 4 per line with compact spacing
+        cluster_tests = sorted(clusters[cluster_name], key=lambda x: x['id'])
+        for i in range(0, len(cluster_tests), 4):
+            batch = cluster_tests[i:i+4]
+            line_parts = []
+
+            for j, test_case in enumerate(batch):
+                test_id = test_case['id']
+                if j < len(batch) - 1:  # Not the last element in the line
+                    # Pad to column_width for uniform spacing
+                    if len(test_id) > column_width:
+                        # If the ID is too long, truncate
+                        padded = test_id[:column_width]
+                    else:
+                        padded = test_id.ljust(column_width)
+                    line_parts.append(padded)
+                else:
+                    # Last element doesn't need padding
+                    line_parts.append(test_id)
+
+            # Add indentation and join with minimal spacing
+            lines.append("  " + "  ".join(line_parts))
+
+    return lines
+
+
+def _generate_detailed_cluster_info(test_cases: List[Dict[str, str]], cluster_name: str) -> List[str]:
+    """Generate detailed information for tests in a specific cluster."""
+    if not test_cases:
+        return [f"No test cases found for cluster: {cluster_name}"]
+
+    lines = []
+    lines.append(f"Test Cases for Cluster: {cluster_name.upper()}")
+    lines.append("=" * (len(f"Test Cases for Cluster: {cluster_name.upper()}")))
+    lines.append("")
+
+    for test_case in test_cases:
+        lines.append(f"ID: {test_case['id']}")
+        lines.append(f"Title: {test_case['title']}")
+        if 'description' in test_case and test_case['description']:
+            # Wrap long descriptions
+            description = test_case['description']
+            if len(description) > 80:
+                # Break description into lines of 80 characters
+                words = description.split()
+                current_line = "Description: "
+                for word in words:
+                    if len(current_line) + len(word) + 1 <= 80:
+                        current_line += word + " "
+                    else:
+                        lines.append(current_line.rstrip())
+                        current_line = "             " + word + " "  # Indent continuation
+                lines.append(current_line.rstrip())
+            else:
+                lines.append(f"Description: {description}")
+        lines.append(f"Collection: {test_case['collection']}")
+        lines.append(f"Suite: {test_case['suite']}")
+        lines.append("-" * 60)
+        lines.append("")
+
+    lines.append(f"Total test cases found: {len(test_cases)}")
+    return lines
+
+
+def _extract_test_cases(test_collections: Any) -> List[Dict[str, str]]:
+    test_cases = []
+
+    # Navigate through the nested structure
+    for collection_name, collection in test_collections.test_collections.items():
+        for suite_name, suite in collection.test_suites.items():
+            for test_case_id, test_case in suite.test_cases.items():
+                test_info = {
+                    'id': test_case.metadata.public_id,
+                    'title': test_case.metadata.title,
+                    'description': test_case.metadata.description if hasattr(test_case.metadata, 'description') else '',
+                    'collection': collection_name,
+                    'suite': suite_name,
+                    'cluster': _extract_cluster_from_test_id(test_case.metadata.public_id)
+                }
+                test_cases.append(test_info)
+
+    return sorted(test_cases, key=lambda x: x['id'])
+
+
+def _extract_cluster_from_test_id(test_id: str) -> str:
+    """Extract cluster name from test ID using regex patterns."""
+
+    # Main regex pattern to handle all common test ID formats:
+    # 1. TC-CLUSTER-X.Y (e.g., TC-ACE-1.1, TC-CADMIN-1.2)
+    # 2. Test_TC_CLUSTER_X_Y (e.g., Test_TC_CC_1_1)
+    # 3. TC_CLUSTER_X_Y (e.g., TC_WEBRTC_1_6, TC_AUDIO_1_6)
+    # 4. TC_CLUSTER-X.Y (mixed format, e.g., TC_WEBRTC-1.2)
+    # 5. TC_Mixed_Case_Clusters (e.g., TC_MCORE_FS_1_1, TC_WebRTCP_2_1)
+
+    patterns = [
+        # Pattern 1: TC-CLUSTER-numbers (dash separated)
+        r'^TC-([A-Z]+)-[\d.]+',
+
+        # Pattern 2: Test_TC_CLUSTER_numbers (underscore separated with Test_ prefix)
+        r'^Test_TC_([A-Z]+)_[\d_]+',
+
+        # Pattern 3: TC_CLUSTER-numbers (mixed underscore/dash format)
+        # Special handling for clusters that end with TC or TCP (like WEBRTC, WEBRTCP)
+        r'^TC_([A-Z]*TCP?)-[\d.]+',  # Matches clusters ending in TC or TCP first
+        r'^TC_([A-Z]+)-[\d.]+',      # Then regular clusters with dash
+
+        # Pattern 4: TC_CLUSTER_numbers (underscore separated)
+        # Handle mixed case clusters (like WebRTCP, WebRTCR, MCORE_FS)
+        r'^TC_([A-Za-z_]+?)_\d+',    # Mixed case clusters with underscores
+
+        # Pattern 5: TC_CLUSTER_numbers (all uppercase, underscore separated)
+        # Special handling for clusters that end with TC or TCP (like WEBRTC, WEBRTCP)
+        r'^TC_([A-Z]*TCP?)_\d+',     # Matches clusters ending in TC or TCP first
+        r'^TC_([A-Z]+)_\d+'          # Then regular clusters
+    ]
+
+    for pattern in patterns:
+        match = re.match(pattern, test_id)
+        if match:
+            cluster = match.group(1)
+            # Convert to uppercase and replace underscores if needed
+            if '_' in cluster or any(c.islower() for c in cluster):
+                # For mixed case or underscore clusters, convert appropriately
+                cluster = cluster.upper().replace('_', '')
+            return cluster
+
+    # Final fallback: extract any sequence of uppercase letters
+    match = re.search(r'([A-Z]{2,})', test_id)
+    if match:
+        return match.group(1)
+
+    return 'UNKNOWN'
+
+
+def _filter_by_cluster(test_cases: List[Dict[str, str]], cluster: str) -> List[Dict[str, str]]:
+    """Filter test cases by cluster name (case insensitive)."""
+    cluster_upper = cluster.upper()
+    return [tc for tc in test_cases if tc['cluster'].upper() == cluster_upper]

--- a/th_cli/commands/available_tests.py
+++ b/th_cli/commands/available_tests.py
@@ -27,6 +27,9 @@ from th_cli.colorize import colorize_cmd_help, colorize_dump, colorize_help
 from th_cli.exceptions import CLIError, handle_api_error
 from th_cli.utils import __json_string, __print_json
 
+# Constants
+COLUMN_WIDTH = 23  # Fixed width for test ID columns with proper spacing
+
 
 @click.command(
     short_help=colorize_help("List all available test cases"),
@@ -125,9 +128,6 @@ def _generate_compact(test_cases: List[Dict[str, str]]) -> List[str]:
 
     lines = []
 
-    # Use a larger fixed width for IDs with more spacing between columns
-    column_width = 23  # Increased from 18 to 23 (added 5 spaces)
-
     # Extract only the IDs
     test_ids = [test_case["id"] for test_case in test_cases]
 
@@ -138,12 +138,12 @@ def _generate_compact(test_cases: List[Dict[str, str]]) -> List[str]:
 
         for j, test_id in enumerate(batch):
             if j < len(batch) - 1:  # Not the last element in the line
-                # Pad to column_width for uniform spacing
-                if len(test_id) > column_width:
+                # Pad to COLUMN_WIDTH for uniform spacing
+                if len(test_id) > COLUMN_WIDTH:
                     # If the ID is too long, truncate
-                    padded = test_id[:column_width]
+                    padded = test_id[:COLUMN_WIDTH]
                 else:
-                    padded = test_id.ljust(column_width)
+                    padded = test_id.ljust(COLUMN_WIDTH)
                 line_parts.append(padded)
             else:
                 # Last element doesn't need padding
@@ -164,9 +164,6 @@ def _generate_grouped_by_cluster(test_cases: List[Dict[str, str]]) -> List[str]:
     for test_case in test_cases:
         clusters[test_case["cluster"]].append(test_case)
 
-    # Use a larger fixed width for IDs with more spacing between columns
-    column_width = 23  # Increased from 18 to 23 (added 5 spaces)
-
     # Generate lines for each cluster
     for cluster_name in sorted(clusters.keys()):
         lines.append(f"\n{cluster_name}:")
@@ -181,12 +178,12 @@ def _generate_grouped_by_cluster(test_cases: List[Dict[str, str]]) -> List[str]:
             for j, test_case in enumerate(batch):
                 test_id = test_case["id"]
                 if j < len(batch) - 1:  # Not the last element in the line
-                    # Pad to column_width for uniform spacing
-                    if len(test_id) > column_width:
+                    # Pad to COLUMN_WIDTH for uniform spacing
+                    if len(test_id) > COLUMN_WIDTH:
                         # If the ID is too long, truncate
-                        padded = test_id[:column_width]
+                        padded = test_id[:COLUMN_WIDTH]
                     else:
-                        padded = test_id.ljust(column_width)
+                        padded = test_id.ljust(COLUMN_WIDTH)
                     line_parts.append(padded)
                 else:
                     # Last element doesn't need padding


### PR DESCRIPTION
### What changed
 Enhanced the th-cli available-tests command with new formatting options, improved pagination, and comprehensive cluster
  extraction for better user experience when browsing Matter certification test cases.
  
New Command Options

  - --compact: Display test IDs only in a clean 4-per-line format with proper column spacing
  - --cluster <NAME>: Filter tests by cluster name (case-insensitive) and show detailed information including ID, title,
  description, collection, and suite
  - --group-by-cluster: Group all test cases by cluster with organized headers and 4-per-line formatting

  Improved Pagination

  - Replaced verbose output with Click's echo_via_pager for git log-style navigation (Enter=1 line, Space=page, q=quit)
  - Applied pagination to all output formats (YAML, JSON, compact, grouped)
  - Maintains original YAML/JSON formatting for default behavior
  
  
  ### Related Issue
  https://github.com/project-chip/certification-tool/issues/822
  
  ### Testing
Test Coverage
  - Added unit test and they are all passing
  
Testing the following commands successfully:

- th-cli available-tests  --cluster WEBRTCR
- th-cli available-tests  --group-by-cluster
- th-cli available-tests  --json > cluster_json.json
- th-cli available-tests  | grep WEBRTCP
- th-cli available-tests  --compact | grep TC_WEBRTC_1_6