### PR TITLE
[Fix] CLI Missing Test Parameter Config

### DIFF
--- a/th_cli/api_lib_autogen/models.py
+++ b/th_cli/api_lib_autogen/models.py
@@ -125,6 +125,7 @@ class TestCollections(BaseModel):
 class TestEnvironmentConfig(BaseModel):
     network: "NetworkConfig" = Field(..., alias="network")
     dut_config: "DutConfig" = Field(..., alias="dut_config")
+    test_parameters: "Optional[Dict[str, Any]]" = Field(None, alias="test_parameters")
 
 
 class TestMetadata(BaseModel):

--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -174,15 +174,15 @@ class TestRunSocket:
                     product_id=product_id,
                 )
 
+                node_id = colorize_key_value("Node ID", chip_info.node_id_hex)
+                click.echo("═══════════════════════════════════════════════════════")
+                click.echo(colorize_header("CHIP Server Information:"))
+                click.echo(f"- {node_id}")
                 if chip_info.manual_pairing_code:
-                    node_id = colorize_key_value("Node ID", chip_info.node_id_hex)
                     manual_code = colorize_key_value("Manual Pairing Code", chip_info.manual_pairing_code)
-                    click.echo("═══════════════════════════════════════════════════════")
-                    click.echo(colorize_header("CHIP Server Information:"))
-                    click.echo(f"- {node_id}")
                     click.echo(f"- {manual_code}")
-                    click.echo("═══════════════════════════════════════════════════════")
-                    click.echo("")
+                click.echo("═══════════════════════════════════════════════════════")
+                click.echo("")
             finally:
                 await client.aclose()
 


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/833
---

# Description

**Fixed** the Client API to include the in the models the Test Parameter attribute from the TestEnvironmentConfig model.

**Also**, the logic to print the chipserver info was fixed to always show the Node ID, even without the manual pairing code

# Testing
We can verify that the Test Parameter is now lister in the CLI's Output (Project Config section):

<img width="851" height="121" alt="Screenshot 2025-12-30 at 17 57 47" src="https://github.com/user-attachments/assets/95142ea2-598c-4aa3-88df-3f8795218fdf" />

Furthermore:
- Unit tests ok
- Sanity tests ok