### PR TITLE
Increase websocket message size

### DIFF
--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -64,8 +64,16 @@ class TestRunSocket:
         self.test_case_step_errors: dict[tuple[int, int], list[str]] = {}
 
     async def connect_websocket(self) -> None:
+        # Configure WebSocket with larger max_size
+        max_size = 32 * 1024 * 1024  # 32MB
 
-        async with websocket_connect(WEBSOCKET_URL, ping_timeout=None) as socket:
+        async with websocket_connect(
+            WEBSOCKET_URL,
+            ping_timeout=None,
+            max_size=max_size,
+            read_limit=max_size,
+            write_limit=max_size
+        ) as socket:
             try:
                 while True:
                     try:

--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -55,6 +55,8 @@ webrtc_indicators = [
     "create_browser_peer",
 ]
 
+WEBSOCKET_MAX_MESSAGE_SIZE = 32 * 1024 * 1024  # 32MB
+
 
 class TestRunSocket:
     def __init__(self, run: TestRunExecutionWithChildren):
@@ -64,15 +66,13 @@ class TestRunSocket:
         self.test_case_step_errors: dict[tuple[int, int], list[str]] = {}
 
     async def connect_websocket(self) -> None:
-        # Configure WebSocket with larger max_size
-        max_size = 32 * 1024 * 1024  # 32MB
 
         async with websocket_connect(
             WEBSOCKET_URL,
             ping_timeout=None,
-            max_size=max_size,
-            read_limit=max_size,
-            write_limit=max_size
+            max_size=WEBSOCKET_MAX_MESSAGE_SIZE,
+            read_limit=WEBSOCKET_MAX_MESSAGE_SIZE,
+            write_limit=WEBSOCKET_MAX_MESSAGE_SIZE,
         ) as socket:
             try:
                 while True:


### PR DESCRIPTION
### What changed
The goal of this PR is to increase the websocket message size in order to fix the `Error: Unexpected error during test execution: sent 1009 (message too big); no close frame received` message.


### Related Issue
https://github.com/project-chip/certification-tool/issues/815

### Testing
Using CLI to run the TC-AVSM-2.2 test case which is one of the test case where the websocket message size error message was displayed and now is passing
<img width="1643" height="559" alt="Screenshot 2026-01-06 at 21 15 40" src="https://github.com/user-attachments/assets/2a202a7a-e9f5-42a2-9b36-5a5d0107c76c" />
