### PR TITLE
Implement CLI Support for Push AV Tests 

### DIFF
--- a/tests/test_run/camera/test_camera_http_server.py
+++ b/tests/test_run/camera/test_camera_http_server.py
@@ -15,13 +15,8 @@
 #
 """Unit tests for camera_http_server module."""
 
-import json
 import queue
-import threading
-import time
-from io import BytesIO
-from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 

--- a/tests/test_run/camera/test_camera_http_server.py
+++ b/tests/test_run/camera/test_camera_http_server.py
@@ -1,0 +1,166 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for camera_http_server module."""
+
+import json
+import queue
+import threading
+import time
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from th_cli.test_run.camera.camera_http_server import (
+    CameraHTTPServer,
+    VideoStreamingHandler,
+)
+
+
+@pytest.mark.unit
+class TestCameraHTTPServer:
+    """Tests for CameraHTTPServer class."""
+
+    def test_init_default_port(self):
+        """Test server initialization with default port."""
+        server = CameraHTTPServer()
+        assert server.port == 8999
+        assert server.server is None
+        assert server.server_thread is None
+
+    def test_init_custom_port(self):
+        """Test server initialization with custom port."""
+        server = CameraHTTPServer(port=9000)
+        assert server.port == 9000
+
+    def test_start_server_success(self):
+        """Test successful server start."""
+        server = CameraHTTPServer(port=0)  # Use port 0 for auto-assignment
+        mp4_queue = queue.Queue()
+        response_queue = queue.Queue()
+        video_handler = Mock()
+
+        with patch('th_cli.test_run.camera.camera_http_server.ThreadingHTTPServer') as mock_server_class:
+            mock_server_instance = Mock()
+            mock_server_class.return_value = mock_server_instance
+
+            with patch('threading.Thread') as mock_thread:
+                mock_thread_instance = Mock()
+                mock_thread.return_value = mock_thread_instance
+
+                server.start(
+                    mp4_queue=mp4_queue,
+                    response_queue=response_queue,
+                    video_handler=video_handler,
+                    prompt_options={"PASS": 1, "FAIL": 2},
+                    prompt_text="Test prompt",
+                    local_ip="192.168.1.100",
+                )
+
+                # Verify server creation and configuration
+                mock_server_class.assert_called_once_with(("0.0.0.0", 0), VideoStreamingHandler)
+                assert mock_server_instance.allow_reuse_address is True
+                assert mock_server_instance.mp4_queue == mp4_queue
+                assert mock_server_instance.response_queue == response_queue
+                assert mock_server_instance.prompt_options == {"PASS": 1, "FAIL": 2}
+                assert mock_server_instance.prompt_text == "Test prompt"
+                assert mock_server_instance.local_ip == "192.168.1.100"
+
+                # Verify thread creation and start
+                mock_thread.assert_called_once()
+                mock_thread_instance.start.assert_called_once()
+
+                # Verify server and thread are stored
+                assert server.server == mock_server_instance
+                assert server.server_thread == mock_thread_instance
+
+    def test_start_server_with_push_av(self):
+        """Test server start with Push AV configuration."""
+        server = CameraHTTPServer(port=0)
+        mp4_queue = queue.Queue()
+        response_queue = queue.Queue()
+
+        with patch('th_cli.test_run.camera.camera_http_server.ThreadingHTTPServer') as mock_server_class:
+            mock_server_instance = Mock()
+            mock_server_class.return_value = mock_server_instance
+
+            with patch('threading.Thread'):
+                server.start(
+                    mp4_queue=mp4_queue,
+                    response_queue=response_queue,
+                    video_handler=None,
+                    prompt_options={"PASS": 1, "FAIL": 2},
+                    prompt_text="Push AV verification",
+                    is_push_av_verification=True,
+                    push_av_server_url="https://localhost:1234",
+                    local_ip="192.168.1.100",
+                )
+
+                assert mock_server_instance.is_push_av_verification is True
+                assert mock_server_instance.push_av_server_url == "https://localhost:1234"
+
+    def test_stop_server(self):
+        """Test server stop."""
+        server = CameraHTTPServer()
+
+        # Mock server and thread
+        mock_server_instance = Mock()
+        mock_thread_instance = Mock()
+        server.server = mock_server_instance
+        server.server_thread = mock_thread_instance
+
+        server.stop()
+
+        # Verify shutdown called and cleanup
+        mock_server_instance.shutdown.assert_called_once()
+        assert server.server is None
+        assert server.server_thread is None
+
+    def test_stop_server_when_not_running(self):
+        """Test stopping server when it's not running."""
+        server = CameraHTTPServer()
+
+        # Should not raise an exception
+        server.stop()
+
+        assert server.server is None
+
+
+@pytest.mark.unit
+class TestVideoStreamingHandler:
+    """Tests for VideoStreamingHandler class."""
+
+    def test_handler_class_exists(self):
+        """Test that VideoStreamingHandler class exists and can be imported."""
+        # Simple test to verify the class exists
+        assert VideoStreamingHandler is not None
+        assert hasattr(VideoStreamingHandler, 'do_GET')
+        assert hasattr(VideoStreamingHandler, 'do_POST')
+        assert hasattr(VideoStreamingHandler, 'do_OPTIONS')
+
+    def test_handler_has_required_methods(self):
+        """Test that handler has all required HTTP methods."""
+        required_methods = [
+            'do_GET', 'do_POST', 'do_OPTIONS',
+            'stream_live_video', 'handle_response',
+            'handle_streams_api', 'handle_stream_proxy',
+            'handle_simple_proxy', 'serve_player'
+        ]
+
+        for method in required_methods:
+            assert hasattr(VideoStreamingHandler, method), f"Missing method: {method}"
+

--- a/tests/test_run/camera/test_camera_http_server.py
+++ b/tests/test_run/camera/test_camera_http_server.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,10 +25,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from th_cli.test_run.camera.camera_http_server import (
-    CameraHTTPServer,
-    VideoStreamingHandler,
-)
+from th_cli.test_run.camera.camera_http_server import CameraHTTPServer, VideoStreamingHandler
 
 
 @pytest.mark.unit
@@ -54,11 +51,11 @@ class TestCameraHTTPServer:
         response_queue = queue.Queue()
         video_handler = Mock()
 
-        with patch('th_cli.test_run.camera.camera_http_server.ThreadingHTTPServer') as mock_server_class:
+        with patch("th_cli.test_run.camera.camera_http_server.ThreadingHTTPServer") as mock_server_class:
             mock_server_instance = Mock()
             mock_server_class.return_value = mock_server_instance
 
-            with patch('threading.Thread') as mock_thread:
+            with patch("threading.Thread") as mock_thread:
                 mock_thread_instance = Mock()
                 mock_thread.return_value = mock_thread_instance
 
@@ -94,11 +91,11 @@ class TestCameraHTTPServer:
         mp4_queue = queue.Queue()
         response_queue = queue.Queue()
 
-        with patch('th_cli.test_run.camera.camera_http_server.ThreadingHTTPServer') as mock_server_class:
+        with patch("th_cli.test_run.camera.camera_http_server.ThreadingHTTPServer") as mock_server_class:
             mock_server_instance = Mock()
             mock_server_class.return_value = mock_server_instance
 
-            with patch('threading.Thread'):
+            with patch("threading.Thread"):
                 server.start(
                     mp4_queue=mp4_queue,
                     response_queue=response_queue,
@@ -148,19 +145,23 @@ class TestVideoStreamingHandler:
         """Test that VideoStreamingHandler class exists and can be imported."""
         # Simple test to verify the class exists
         assert VideoStreamingHandler is not None
-        assert hasattr(VideoStreamingHandler, 'do_GET')
-        assert hasattr(VideoStreamingHandler, 'do_POST')
-        assert hasattr(VideoStreamingHandler, 'do_OPTIONS')
+        assert hasattr(VideoStreamingHandler, "do_GET")
+        assert hasattr(VideoStreamingHandler, "do_POST")
+        assert hasattr(VideoStreamingHandler, "do_OPTIONS")
 
     def test_handler_has_required_methods(self):
         """Test that handler has all required HTTP methods."""
         required_methods = [
-            'do_GET', 'do_POST', 'do_OPTIONS',
-            'stream_live_video', 'handle_response',
-            'handle_streams_api', 'handle_stream_proxy',
-            'handle_simple_proxy', 'serve_player'
+            "do_GET",
+            "do_POST",
+            "do_OPTIONS",
+            "stream_live_video",
+            "handle_response",
+            "handle_streams_api",
+            "handle_stream_proxy",
+            "handle_simple_proxy",
+            "serve_player",
         ]
 
         for method in required_methods:
             assert hasattr(VideoStreamingHandler, method), f"Missing method: {method}"
-

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -267,61 +267,6 @@ class TestHandlePrompt:
 
 
 @pytest.mark.unit
-class TestValidTextInput:
-    """Tests for __valid_text_input function."""
-
-    def test_valid_text_input_no_regex(self):
-        """Test validation with no regex pattern."""
-        # Test verifies the validation logic exists in the codebase
-        assert True
-
-    def test_valid_text_input_with_regex_match(self):
-        """Test validation with matching regex pattern."""
-        # Test verifies the validation logic exists in the codebase
-        assert True
-
-    def test_valid_text_input_with_regex_no_match(self):
-        """Test validation with non-matching regex pattern."""
-        # Test verifies the validation logic exists in the codebase
-        assert True
-
-    def test_valid_text_input_not_string(self):
-        """Test validation with non-string input."""
-        # Test verifies the validation logic exists in the codebase
-        assert True
-
-
-@pytest.mark.unit
-class TestValidFileUpload:
-    """Tests for __valid_file_upload function."""
-
-    def test_valid_file_upload_txt_file(self, temp_dir):
-        """Test validation with valid .txt file."""
-        # Test verifies file validation logic exists in the codebase
-        assert True
-
-    def test_valid_file_upload_log_file(self, temp_dir):
-        """Test validation with valid .log file."""
-        # Test verifies file validation logic exists in the codebase
-        assert True
-
-    def test_valid_file_upload_invalid_extension(self, temp_dir):
-        """Test validation with invalid file extension."""
-        # Test verifies file validation logic exists in the codebase
-        assert True
-
-    def test_valid_file_upload_nonexistent_file(self):
-        """Test validation with nonexistent file."""
-        # Test verifies file validation logic exists in the codebase
-        assert True
-
-    def test_valid_file_upload_directory(self, temp_dir):
-        """Test validation with directory instead of file."""
-        # Test verifies file validation logic exists in the codebase
-        assert True
-
-
-@pytest.mark.unit
 class TestSendPromptResponse:
     """Tests for _send_prompt_response function."""
 

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -17,8 +17,6 @@
 
 import asyncio
 import json
-import queue
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -140,7 +140,7 @@ class TestHandlePrompt:
             image_hex_str="ffd8ffe0",
         )
 
-        with patch("th_cli.test_run.prompt_manager.__handle_image_verification_prompt") as mock_handler:
+        with patch("th_cli.test_run.prompt_manager._handle_image_verification_prompt") as mock_handler:
             mock_handler.return_value = asyncio.Future()
             mock_handler.return_value.set_result(None)
 
@@ -186,7 +186,7 @@ class TestHandlePrompt:
             options={"PASS": 1, "FAIL": 2},
         )
 
-        with patch("th_cli.test_run.prompt_manager.__handle_push_av_stream_prompt") as mock_handler:
+        with patch("th_cli.test_run.prompt_manager._handle_push_av_stream_prompt") as mock_handler:
             mock_handler.return_value = asyncio.Future()
             mock_handler.return_value.set_result(None)
 

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 """Unit tests for prompt_manager module."""
 
 import asyncio
+import json
 import queue
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from th_cli.shared_constants import MessageTypeEnum
 from th_cli.test_run import prompt_manager
 from th_cli.test_run.socket_schemas import (
     ImageVerificationPromptRequest,
@@ -32,7 +34,6 @@ from th_cli.test_run.socket_schemas import (
     TextInputPromptRequest,
     UserResponseStatusEnum,
 )
-from th_cli.shared_constants import MessageTypeEnum
 
 
 @pytest.mark.unit
@@ -118,9 +119,7 @@ class TestCleanupVideoHandler:
     async def test_cleanup_video_handler_error_ignored(self):
         """Test that cleanup errors are ignored."""
         mock_instance = MagicMock()
-        mock_instance.stop_video_capture_and_stream = AsyncMock(
-            side_effect=Exception("Cleanup error")
-        )
+        mock_instance.stop_video_capture_and_stream = AsyncMock(side_effect=Exception("Cleanup error"))
         prompt_manager._video_handler_instance = mock_instance
 
         # Should not raise an exception
@@ -343,8 +342,6 @@ class TestSendPromptResponse:
         mock_socket.send.assert_called_once()
         call_args = mock_socket.send.call_args[0][0]
 
-        # Verify JSON structure
-        import json
         payload = json.loads(call_args)
         assert payload["type"] == "prompt_response"
         assert payload["payload"]["response"] == "test response"
@@ -368,7 +365,6 @@ class TestSendPromptResponse:
         mock_socket.send.assert_called_once()
         call_args = mock_socket.send.call_args[0][0]
 
-        import json
         payload = json.loads(call_args)
         assert payload["payload"]["status_code"] == UserResponseStatusEnum.CANCELLED
 

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -1,0 +1,403 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for prompt_manager module."""
+
+import asyncio
+import queue
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from th_cli.test_run import prompt_manager
+from th_cli.test_run.socket_schemas import (
+    ImageVerificationPromptRequest,
+    MessagePromptRequest,
+    OptionsSelectPromptRequest,
+    PushAVStreamVerificationRequest,
+    StreamVerificationPromptRequest,
+    TextInputPromptRequest,
+    UserResponseStatusEnum,
+)
+from th_cli.shared_constants import MessageTypeEnum
+
+
+@pytest.mark.unit
+class TestGetLocalIp:
+    """Tests for _get_local_ip function."""
+
+    def test_get_local_ip_success(self):
+        """Test successful local IP retrieval."""
+        with patch("socket.socket") as mock_socket:
+            mock_sock = MagicMock()
+            mock_sock.getsockname.return_value = ("192.168.1.100", 12345)
+            mock_socket.return_value.__enter__.return_value = mock_sock
+
+            result = prompt_manager._get_local_ip()
+
+            assert result == "192.168.1.100"
+            mock_sock.connect.assert_called_once_with(("8.8.8.8", 80))
+
+    def test_get_local_ip_fallback_on_error(self):
+        """Test fallback to localhost on connection error."""
+        with patch("socket.socket") as mock_socket:
+            mock_socket.return_value.__enter__.side_effect = Exception("Network error")
+
+            result = prompt_manager._get_local_ip()
+
+            assert result == "localhost"
+
+
+@pytest.mark.unit
+class TestGetVideoHandler:
+    """Tests for _get_video_handler function."""
+
+    def test_get_video_handler_creates_instance(self):
+        """Test that video handler instance is created on first call."""
+        # Reset global instance
+        prompt_manager._video_handler_instance = None
+
+        with patch("th_cli.test_run.camera.CameraStreamHandler") as mock_handler:
+            mock_instance = MagicMock()
+            mock_handler.return_value = mock_instance
+
+            result = prompt_manager._get_video_handler()
+
+            assert result == mock_instance
+            mock_handler.assert_called_once()
+
+    def test_get_video_handler_reuses_instance(self):
+        """Test that video handler instance is reused on subsequent calls."""
+        mock_instance = MagicMock()
+        prompt_manager._video_handler_instance = mock_instance
+
+        with patch("th_cli.test_run.camera.CameraStreamHandler") as mock_handler:
+            result = prompt_manager._get_video_handler()
+
+            assert result == mock_instance
+            mock_handler.assert_not_called()
+
+
+@pytest.mark.unit
+class TestCleanupVideoHandler:
+    """Tests for _cleanup_video_handler function."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_video_handler_success(self):
+        """Test successful cleanup of video handler."""
+        mock_instance = MagicMock()
+        mock_instance.stop_video_capture_and_stream = AsyncMock()
+        prompt_manager._video_handler_instance = mock_instance
+
+        await prompt_manager._cleanup_video_handler()
+
+        mock_instance.stop_video_capture_and_stream.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_video_handler_no_instance(self):
+        """Test cleanup when no instance exists."""
+        prompt_manager._video_handler_instance = None
+
+        # Should not raise an exception
+        await prompt_manager._cleanup_video_handler()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_video_handler_error_ignored(self):
+        """Test that cleanup errors are ignored."""
+        mock_instance = MagicMock()
+        mock_instance.stop_video_capture_and_stream = AsyncMock(
+            side_effect=Exception("Cleanup error")
+        )
+        prompt_manager._video_handler_instance = mock_instance
+
+        # Should not raise an exception
+        await prompt_manager._cleanup_video_handler()
+
+
+@pytest.mark.unit
+class TestHandlePrompt:
+    """Tests for handle_prompt function."""
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_image_verification(self):
+        """Test routing to image verification handler."""
+        mock_socket = AsyncMock()
+        mock_request = ImageVerificationPromptRequest(
+            message_id=1,
+            prompt="Verify image",
+            timeout=30,
+            options={"PASS": 1, "FAIL": 2},
+            image_hex_str="ffd8ffe0",
+        )
+
+        with patch("th_cli.test_run.prompt_manager.__handle_image_verification_prompt") as mock_handler:
+            mock_handler.return_value = asyncio.Future()
+            mock_handler.return_value.set_result(None)
+
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_request,
+                message_type=MessageTypeEnum.IMAGE_VERIFICATION_REQUEST,
+            )
+
+            mock_handler.assert_called_once_with(socket=mock_socket, prompt=mock_request)
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_stream_verification(self):
+        """Test routing to stream verification handler."""
+        mock_socket = AsyncMock()
+        mock_request = StreamVerificationPromptRequest(
+            message_id=2,
+            prompt="Verify stream",
+            timeout=120,
+            options={"PASS": 1, "FAIL": 2},
+        )
+
+        with patch("th_cli.test_run.prompt_manager.__handle_stream_verification_prompt") as mock_handler:
+            mock_handler.return_value = asyncio.Future()
+            mock_handler.return_value.set_result(None)
+
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_request,
+                message_type=MessageTypeEnum.STREAM_VERIFICATION_REQUEST,
+            )
+
+            mock_handler.assert_called_once_with(socket=mock_socket, prompt=mock_request)
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_push_av_stream(self):
+        """Test routing to Push AV stream handler."""
+        mock_socket = AsyncMock()
+        mock_request = PushAVStreamVerificationRequest(
+            message_id=3,
+            prompt="Verify Push AV stream",
+            timeout=120,
+            options={"PASS": 1, "FAIL": 2},
+        )
+
+        with patch("th_cli.test_run.prompt_manager.__handle_push_av_stream_prompt") as mock_handler:
+            mock_handler.return_value = asyncio.Future()
+            mock_handler.return_value.set_result(None)
+
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_request,
+                message_type=MessageTypeEnum.PUSH_AV_STREAM_VERIFICATION_REQUEST,
+            )
+
+            mock_handler.assert_called_once_with(socket=mock_socket, prompt=mock_request)
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_message_request(self):
+        """Test routing to message handler."""
+        mock_socket = AsyncMock()
+        mock_request = MessagePromptRequest(
+            message_id=4,
+            prompt="Acknowledge this message",
+            timeout=30,
+        )
+
+        with patch("th_cli.test_run.prompt_manager.__handle_message_prompt") as mock_handler:
+            mock_handler.return_value = asyncio.Future()
+            mock_handler.return_value.set_result(None)
+
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_request,
+                message_type=MessageTypeEnum.MESSAGE_REQUEST,
+            )
+
+            mock_handler.assert_called_once_with(socket=mock_socket, prompt=mock_request)
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_options_select(self):
+        """Test routing to options prompt handler."""
+        mock_socket = AsyncMock()
+        mock_request = OptionsSelectPromptRequest(
+            message_id=5,
+            prompt="Select an option",
+            timeout=30,
+            options={"Option 1": 1, "Option 2": 2},
+        )
+
+        with patch("th_cli.test_run.prompt_manager.__handle_options_prompt") as mock_handler:
+            mock_handler.return_value = asyncio.Future()
+            mock_handler.return_value.set_result(None)
+
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_request,
+            )
+
+            mock_handler.assert_called_once_with(socket=mock_socket, prompt=mock_request)
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_text_input(self):
+        """Test routing to text input handler."""
+        mock_socket = AsyncMock()
+        mock_request = TextInputPromptRequest(
+            message_id=6,
+            prompt="Enter text",
+            timeout=30,
+        )
+
+        with patch("th_cli.test_run.prompt_manager.__handle_text_prompt") as mock_handler:
+            mock_handler.return_value = asyncio.Future()
+            mock_handler.return_value.set_result(None)
+
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_request,
+            )
+
+            mock_handler.assert_called_once_with(socket=mock_socket, prompt=mock_request)
+
+
+@pytest.mark.unit
+class TestValidTextInput:
+    """Tests for __valid_text_input function."""
+
+    def test_valid_text_input_no_regex(self):
+        """Test validation with no regex pattern."""
+        # Test verifies the validation logic exists in the codebase
+        assert True
+
+    def test_valid_text_input_with_regex_match(self):
+        """Test validation with matching regex pattern."""
+        # Test verifies the validation logic exists in the codebase
+        assert True
+
+    def test_valid_text_input_with_regex_no_match(self):
+        """Test validation with non-matching regex pattern."""
+        # Test verifies the validation logic exists in the codebase
+        assert True
+
+    def test_valid_text_input_not_string(self):
+        """Test validation with non-string input."""
+        # Test verifies the validation logic exists in the codebase
+        assert True
+
+
+@pytest.mark.unit
+class TestValidFileUpload:
+    """Tests for __valid_file_upload function."""
+
+    def test_valid_file_upload_txt_file(self, temp_dir):
+        """Test validation with valid .txt file."""
+        # Test verifies file validation logic exists in the codebase
+        assert True
+
+    def test_valid_file_upload_log_file(self, temp_dir):
+        """Test validation with valid .log file."""
+        # Test verifies file validation logic exists in the codebase
+        assert True
+
+    def test_valid_file_upload_invalid_extension(self, temp_dir):
+        """Test validation with invalid file extension."""
+        # Test verifies file validation logic exists in the codebase
+        assert True
+
+    def test_valid_file_upload_nonexistent_file(self):
+        """Test validation with nonexistent file."""
+        # Test verifies file validation logic exists in the codebase
+        assert True
+
+    def test_valid_file_upload_directory(self, temp_dir):
+        """Test validation with directory instead of file."""
+        # Test verifies file validation logic exists in the codebase
+        assert True
+
+
+@pytest.mark.unit
+class TestSendPromptResponse:
+    """Tests for _send_prompt_response function."""
+
+    @pytest.mark.asyncio
+    async def test_send_prompt_response_success(self):
+        """Test successful prompt response sending."""
+        mock_socket = AsyncMock()
+        mock_prompt = Mock()
+        mock_prompt.message_id = 123
+
+        await prompt_manager._send_prompt_response(
+            socket=mock_socket,
+            prompt=mock_prompt,
+            response="test response",
+            status_code=UserResponseStatusEnum.OKAY,
+        )
+
+        mock_socket.send.assert_called_once()
+        call_args = mock_socket.send.call_args[0][0]
+
+        # Verify JSON structure
+        import json
+        payload = json.loads(call_args)
+        assert payload["type"] == "prompt_response"
+        assert payload["payload"]["response"] == "test response"
+        assert payload["payload"]["status_code"] == UserResponseStatusEnum.OKAY
+        assert payload["payload"]["message_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_send_prompt_response_cancelled_status(self):
+        """Test prompt response with CANCELLED status."""
+        mock_socket = AsyncMock()
+        mock_prompt = Mock()
+        mock_prompt.message_id = 456
+
+        await prompt_manager._send_prompt_response(
+            socket=mock_socket,
+            prompt=mock_prompt,
+            response="Stream failed",
+            status_code=UserResponseStatusEnum.CANCELLED,
+        )
+
+        mock_socket.send.assert_called_once()
+        call_args = mock_socket.send.call_args[0][0]
+
+        import json
+        payload = json.loads(call_args)
+        assert payload["payload"]["status_code"] == UserResponseStatusEnum.CANCELLED
+
+
+@pytest.mark.unit
+class TestHandleMessagePrompt:
+    """Tests for __handle_message_prompt function."""
+
+    @pytest.mark.asyncio
+    async def test_handle_message_prompt_success(self):
+        """Test successful message prompt handling."""
+        # Test the message handling through the main handler
+        mock_socket = AsyncMock()
+        mock_prompt = MessagePromptRequest(
+            message_id=1,
+            prompt="Test message",
+            timeout=30,
+        )
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response") as mock_send:
+            mock_send.return_value = asyncio.Future()
+            mock_send.return_value.set_result(None)
+
+            # Test through the main handle_prompt function
+            await prompt_manager.handle_prompt(
+                socket=mock_socket,
+                request=mock_prompt,
+                message_type="message_request",
+            )
+
+            # Verify the response was sent (indirectly tests the private function)
+            mock_send.assert_called_once()

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -18,7 +18,6 @@ import html
 import json
 import queue
 import re
-import ssl
 import threading
 import time
 import urllib.parse

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import html
+import base64
 import json
 import queue
 import re
@@ -240,8 +241,6 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
         This allows dash.js to append paths naturally.
         """
         try:
-            import base64
-
             # Extract path after /proxy/
             path_after_proxy = self.path[len("/proxy/") :]
 
@@ -329,8 +328,6 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
 
                     # For DASH manifests, use simplified base64-encoded proxy
                     # This allows dash.js to naturally append paths for segment templates
-
-                    import base64
 
                     # Extract base URL from stream_url (the directory containing the manifest)
                     base_url = "/".join(stream_url.rsplit("/", 1)[:-1])  # Remove filename

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -41,15 +41,20 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         logger.info(f"GET request received: {self.path}")
-        if self.path == ENDPOINT_VIDEO_LIVE:
+
+        # Parse URL to strip query parameters for routing
+        parsed_url = urlparse(self.path)
+        path_only = parsed_url.path
+
+        if path_only == ENDPOINT_VIDEO_LIVE:
             self.stream_live_video()
-        elif self.path == ENDPOINT_ROOT:
+        elif path_only == ENDPOINT_ROOT:
             self.serve_player()
-        elif self.path == ENDPOINT_API_STREAMS:
+        elif path_only == ENDPOINT_API_STREAMS:
             self.handle_streams_api()
-        elif self.path.startswith(ENDPOINT_API_STREAM_PROXY):
+        elif path_only.startswith(ENDPOINT_API_STREAM_PROXY):
             self.handle_stream_proxy()
-        elif self.path.startswith('/proxy/'):
+        elif path_only.startswith("/proxy/"):
             # New simplified proxy endpoint: /proxy/<base64_encoded_url>
             self.handle_simple_proxy()
         else:
@@ -238,41 +243,47 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
             import base64
 
             # Extract path after /proxy/
-            path_after_proxy = self.path[len('/proxy/'):]
+            path_after_proxy = self.path[len("/proxy/") :]
 
             # Split to get base64 URL and any additional path
-            parts = path_after_proxy.split('/', 1)
+            parts = path_after_proxy.split("/", 1)
             encoded_base = parts[0]
-            extra_path = '/' + parts[1] if len(parts) > 1 else ''
+            extra_path = "/" + parts[1] if len(parts) > 1 else ""
 
             # Decode base URL
             try:
-                base_url = base64.urlsafe_b64decode(encoded_base.encode()).decode('utf-8')
+                base_url = base64.urlsafe_b64decode(encoded_base.encode()).decode("utf-8")
             except Exception as e:
                 logger.error(f"Failed to decode base64 URL: {e}")
                 self.send_error(400, "Invalid encoded URL")
                 return
 
             # Construct full URL
-            stream_url = base_url.rstrip('/') + extra_path
-            logger.info(f"Simple proxy: {stream_url}")
+            stream_url = base_url.rstrip("/") + extra_path
 
             # Fetch from upstream
             with httpx.Client(verify=False, timeout=30.0) as client:
-                response = client.get(stream_url)
-
-                if response.status_code != 200:
-                    self.send_error(response.status_code, "Upstream error")
+                try:
+                    response = client.get(stream_url)
+                except Exception as e:
+                    logger.error(f"Failed to fetch {stream_url}: {e}")
+                    self.send_error(500, f"Upstream fetch error: {str(e)}")
                     return
 
-                content_type = response.headers.get('Content-Type', 'application/octet-stream')
+                if response.status_code != 200:
+                    logger.warning(f"Upstream returned {response.status_code} for {stream_url}")
+                    # Return the same status code from upstream (404, 403, etc.)
+                    self.send_error(response.status_code, f"Upstream returned {response.status_code}")
+                    return
+
+                content_type = response.headers.get("Content-Type", "application/octet-stream")
 
                 # Send response
                 self.send_response(200)
                 self.send_header("Content-Type", content_type)
                 self.send_header("Access-Control-Allow-Origin", "*")
 
-                content_length = response.headers.get('Content-Length')
+                content_length = response.headers.get("Content-Length")
                 if content_length:
                     self.send_header("Content-Length", content_length)
 
@@ -280,41 +291,28 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                 self.wfile.write(response.content)
 
         except Exception as e:
-            logger.error(f"Error in simple proxy: {e}")
+            logger.error(f"Error in simple proxy: {e}", exc_info=True)
             if not self.wfile.closed:
                 self.send_error(500, f"Proxy error: {str(e)}")
 
     def handle_stream_proxy(self):
         """Proxy video stream from Push AV Server to avoid CORS and SSL issues."""
         try:
-            logger.info(f"Proxy request path: {self.path}")
-
-            # Parse the full path - dash.js may append paths after the query parameter
-            # Example: /api/stream_proxy?url=<encoded_base>/media/segment_1001.m4s
-            # or: /api/stream_proxy/media/segment_1001.m4s?url=<encoded_base>
             parsed_url = urlparse(self.path)
-
-            # Parse query parameters
             query_params = parse_qs(parsed_url.query)
-            stream_url = query_params.get('url', [None])[0]
+            stream_url = query_params.get("url", [None])[0]
 
             if not stream_url:
                 self.send_error(400, "Missing 'url' parameter")
                 return
 
             # Check if there's additional path after /api/stream_proxy
-            # This handles when dash.js appends paths like /media/segment_1001.m4s
             path = parsed_url.path
-            if path.startswith('/api/stream_proxy/'):
-                # Extract the extra path after /api/stream_proxy/
-                extra_path = path[len('/api/stream_proxy'):]  # e.g., /media/segment_1001.m4s
-                stream_url = stream_url.rstrip('/') + extra_path
-                logger.info(f"Appended path from URL: {extra_path}")
+            if path.startswith("/api/stream_proxy/"):
+                extra_path = path[len("/api/stream_proxy") :]
+                stream_url = stream_url.rstrip("/") + extra_path
 
-            logger.info(f"Proxying stream from: {stream_url}")
-
-            # Fetch from Push AV Server
-            # Disable SSL verification for self-signed certificates
+            # Fetch from Push AV Server (disable SSL verification for self-signed certificates)
             with httpx.Client(verify=False, timeout=30.0) as client:
                 response = client.get(stream_url)
 
@@ -322,17 +320,12 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                     self.send_error(response.status_code, f"Upstream error")
                     return
 
-                content_type = response.headers.get('Content-Type', 'video/mp4')
+                content_type = response.headers.get("Content-Type", "video/mp4")
 
                 # Check if this is an MPD manifest file
-                if stream_url.endswith('.mpd') or 'mpd' in content_type.lower():
-                    # This is a DASH manifest - rewrite URLs to use our proxy
-                    logger.info("Rewriting MPD manifest URLs")
-
+                if stream_url.endswith(".mpd") or "mpd" in content_type.lower():
+                    # Rewrite DASH manifest URLs to use our proxy
                     content = response.text
-
-                    # Log original manifest for debugging
-                    logger.debug(f"Original MPD manifest:\n{content[:500]}")
 
                     # For DASH manifests, use simplified base64-encoded proxy
                     # This allows dash.js to naturally append paths for segment templates
@@ -340,14 +333,17 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                     import base64
 
                     # Extract base URL from stream_url (the directory containing the manifest)
-                    base_url = '/'.join(stream_url.rsplit('/', 1)[:-1])  # Remove filename
-                    logger.info(f"Base URL: {base_url}")
+                    base_url = "/".join(stream_url.rsplit("/", 1)[:-1])  # Remove filename
 
                     # Encode the base URL for use in proxy path
-                    encoded_base = base64.urlsafe_b64encode(base_url.encode()).decode('ascii')
+                    encoded_base = base64.urlsafe_b64encode(base_url.encode()).decode("ascii")
 
                     # Remove all existing BaseURL elements
-                    content = re.sub(r'<BaseURL>[^<]+</BaseURL>', '', content)
+                    content = re.sub(r"<BaseURL>[^<]+</BaseURL>", "", content)
+
+                    # Get local IP and port from server configuration
+                    local_ip = getattr(self.server, "local_ip", "localhost")
+                    port = self.server.server_port
 
                     # Rewrite non-template attributes (like initialization)
                     def rewrite_media_url(match):
@@ -355,57 +351,54 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                         original_url = match.group(2)
 
                         # Skip template URLs - leave them as-is, BaseURL will handle them
-                        if '$' in original_url:
-                            logger.debug(f"Preserving template: {attr_name}=\"{original_url}\"")
+                        if "$" in original_url:
                             return match.group(0)
 
                         # For non-template URLs, make them absolute
-                        if original_url.startswith('http'):
+                        if original_url.startswith("http"):
                             full_url = original_url
                         else:
                             full_url = f"{base_url}/{original_url}"
 
-                        # Use simple proxy format
-                        encoded_url = base64.urlsafe_b64encode(full_url.encode()).decode('ascii')
-                        proxied_url = f"http://192.168.20.180:8999/proxy/{encoded_url}"
+                        # Use simple proxy format with dynamic host
+                        encoded_url = base64.urlsafe_b64encode(full_url.encode()).decode("ascii")
+                        proxied_url = f"http://{local_ip}:{port}/proxy/{encoded_url}"
 
-                        logger.debug(f"Rewriting {attr_name}=\"{original_url}\" -> \"{proxied_url}\"")
                         return f'{attr_name}="{proxied_url}"'
 
                     content = re.sub(r'(initialization|sourceURL)="([^"]+)"', rewrite_media_url, content)
 
-                    # Add BaseURL using the simplified proxy format
+                    # Add BaseURL using the simplified proxy format with dynamic host
                     # dash.js will append media template paths to this
-                    proxied_base = f"http://192.168.20.180:8999/proxy/{encoded_base}"
+                    proxied_base = f"http://{local_ip}:{port}/proxy/{encoded_base}"
 
                     # Insert BaseURL at the beginning of the first Period
-                    if '<Period>' in content:
-                        content = content.replace('<Period>', f'<Period><BaseURL>{proxied_base}/</BaseURL>', 1)
-                    elif '<MPD' in content:
+                    if "<Period>" in content:
+                        content = content.replace("<Period>", f"<Period><BaseURL>{proxied_base}/</BaseURL>", 1)
+                    elif "<MPD" in content:
                         # Insert after MPD opening tag
-                        mpd_end = content.find('>', content.find('<MPD'))
+                        mpd_end = content.find(">", content.find("<MPD"))
                         if mpd_end > 0:
-                            content = content[:mpd_end+1] + f'\n<BaseURL>{proxied_base}/</BaseURL>\n' + content[mpd_end+1:]
-
-                    logger.info(f"=== REWRITTEN MPD MANIFEST ===")
-                    logger.info(content)
-                    logger.info(f"=== END MPD MANIFEST ===")
+                            content = (
+                                content[: mpd_end + 1]
+                                + f"\n<BaseURL>{proxied_base}/</BaseURL>\n"
+                                + content[mpd_end + 1 :]
+                            )
 
                     # Send modified manifest
                     self.send_response(200)
                     self.send_header("Content-Type", "application/dash+xml")
                     self.send_header("Access-Control-Allow-Origin", "*")
-                    self.send_header("Content-Length", str(len(content.encode('utf-8'))))
+                    self.send_header("Content-Length", str(len(content.encode("utf-8"))))
                     self.end_headers()
-                    self.wfile.write(content.encode('utf-8'))
-                    logger.info("Sent rewritten MPD manifest")
+                    self.wfile.write(content.encode("utf-8"))
                 else:
                     # Regular file - stream as-is
                     self.send_response(200)
                     self.send_header("Content-Type", content_type)
                     self.send_header("Access-Control-Allow-Origin", "*")
 
-                    content_length = response.headers.get('Content-Length')
+                    content_length = response.headers.get("Content-Length")
                     if content_length:
                         self.send_header("Content-Length", content_length)
 
@@ -452,11 +445,18 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                 html_template = f.read()
 
             # Replace placeholders
-            html_content = html_template.format(
-                prompt_text=html.escape(prompt_text),
-                radio_options_html=radio_options_html,
-                push_av_server_url=html.escape(push_av_server_url)
-            )
+            if is_push_av:
+                # Push AV template needs the server URL
+                html_content = html_template.format(
+                    prompt_text=html.escape(prompt_text),
+                    radio_options_html=radio_options_html,
+                    push_av_server_url=html.escape(push_av_server_url or "https://localhost:1234"),
+                )
+            else:
+                # Regular video verification template doesn't need Push AV server URL
+                html_content = html_template.format(
+                    prompt_text=html.escape(prompt_text), radio_options_html=radio_options_html
+                )
         except Exception as e:
             logger.error(f"Failed to load HTML template: {e}")
             # Fallback to simple HTML
@@ -474,6 +474,15 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
 
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
+        # Aggressive cache prevention - multiple headers to bypass all browser caching
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, private")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        self.send_header("Last-Modified", "0")
+        # Add ETag to force browser to check for changes
+        import time
+
+        self.send_header("ETag", f'"{int(time.time())}"')
         self.end_headers()
         self.wfile.write(html_content.encode("utf-8"))
 
@@ -499,6 +508,7 @@ class CameraHTTPServer:
         prompt_text="Video Verification",
         is_push_av_verification=False,
         push_av_server_url=None,
+        local_ip=None,
     ):
         """Start HTTP server with required queues and data."""
         try:
@@ -514,6 +524,7 @@ class CameraHTTPServer:
             self.server.video_handler = video_handler
             self.server.is_push_av_verification = is_push_av_verification
             self.server.push_av_server_url = push_av_server_url
+            self.server.local_ip = local_ip or "localhost"
 
             logger.info(f"HTTP server configured with prompt_options: {self.server.prompt_options}")
             logger.info(f"HTTP server configured with prompt_text: {self.server.prompt_text}")

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import html
 import base64
+import html
 import json
 import queue
 import re
 import ssl
 import threading
+import time
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -35,6 +36,10 @@ ENDPOINT_VIDEO_LIVE = "/video_live.mp4"
 ENDPOINT_SUBMIT_RESPONSE = "/submit_response"
 ENDPOINT_API_STREAMS = "/api/streams"
 ENDPOINT_API_STREAM_PROXY = "/api/stream_proxy"
+
+# Timeout constants (in seconds)
+PUSH_AV_STREAMS_TIMEOUT = 5.0  # Timeout for fetching stream list
+PUSH_AV_PROXY_TIMEOUT = 30.0  # Timeout for proxying stream data
 
 
 class VideoStreamingHandler(BaseHTTPRequestHandler):
@@ -210,8 +215,11 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                 return
 
             # Fetch streams from Push AV Server
-            # Disable SSL verification for self-signed certificates
-            with httpx.Client(verify=False, timeout=5.0) as client:
+            # Disable SSL verification for self-signed certificates in test environments.
+            # Push AV Servers typically use self-signed certificates. This is acceptable
+            # since we're connecting to test devices in controlled lab settings, similar
+            # to how browsers prompt users to accept self-signed certificates in the TH web UI.
+            with httpx.Client(verify=False, timeout=PUSH_AV_STREAMS_TIMEOUT) as client:
                 response = client.get(f"{push_av_server_url}/streams")
 
                 if response.status_code == 200:
@@ -261,7 +269,11 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
             stream_url = base_url.rstrip("/") + extra_path
 
             # Fetch from upstream
-            with httpx.Client(verify=False, timeout=30.0) as client:
+            # Disable SSL verification for self-signed certificates in test environments.
+            # Push AV Servers typically use self-signed certificates. This is acceptable
+            # since we're connecting to test devices in controlled lab settings, similar
+            # to how browsers prompt users to accept self-signed certificates in the TH web UI.
+            with httpx.Client(verify=False, timeout=PUSH_AV_PROXY_TIMEOUT) as client:
                 try:
                     response = client.get(stream_url)
                 except Exception as e:
@@ -311,8 +323,12 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                 extra_path = path[len("/api/stream_proxy") :]
                 stream_url = stream_url.rstrip("/") + extra_path
 
-            # Fetch from Push AV Server (disable SSL verification for self-signed certificates)
-            with httpx.Client(verify=False, timeout=30.0) as client:
+            # Fetch from Push AV Server
+            # Disable SSL verification for self-signed certificates in test environments.
+            # Push AV Servers typically use self-signed certificates. This is acceptable
+            # since we're connecting to test devices in controlled lab settings, similar
+            # to how browsers prompt users to accept self-signed certificates in the TH web UI.
+            with httpx.Client(verify=False, timeout=PUSH_AV_PROXY_TIMEOUT) as client:
                 response = client.get(stream_url)
 
                 if response.status_code != 200:
@@ -472,9 +488,8 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
         self.send_header("Pragma", "no-cache")
         self.send_header("Expires", "0")
         self.send_header("Last-Modified", "0")
-        # Add ETag to force browser to check for changes
-        import time
 
+        # Add ETag to force browser to check for changes
         self.send_header("ETag", f'"{int(time.time())}"')
         self.end_headers()
         self.wfile.write(html_content.encode("utf-8"))

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -16,17 +16,24 @@
 import html
 import json
 import queue
+import re
+import ssl
 import threading
+import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
+import httpx
 from loguru import logger
 
 # HTTP Endpoints
 ENDPOINT_ROOT = "/"
 ENDPOINT_VIDEO_LIVE = "/video_live.mp4"
 ENDPOINT_SUBMIT_RESPONSE = "/submit_response"
+ENDPOINT_API_STREAMS = "/api/streams"
+ENDPOINT_API_STREAM_PROXY = "/api/stream_proxy"
 
 
 class VideoStreamingHandler(BaseHTTPRequestHandler):
@@ -38,6 +45,13 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
             self.stream_live_video()
         elif self.path == ENDPOINT_ROOT:
             self.serve_player()
+        elif self.path == ENDPOINT_API_STREAMS:
+            self.handle_streams_api()
+        elif self.path.startswith(ENDPOINT_API_STREAM_PROXY):
+            self.handle_stream_proxy()
+        elif self.path.startswith('/proxy/'):
+            # New simplified proxy endpoint: /proxy/<base64_encoded_url>
+            self.handle_simple_proxy()
         else:
             logger.warning(f"404 for GET {self.path}")
             self.send_error(404)
@@ -176,31 +190,272 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(f'{{"error": "Server error: {str(e)}"}}'.encode())
 
+    def handle_streams_api(self):
+        """Fetch and return available streams from Push AV Server."""
+        try:
+            push_av_server_url = getattr(self.server, "push_av_server_url", None)
+
+            if not push_av_server_url:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(b'{"error": "Push AV Server URL not configured"}')
+                return
+
+            # Fetch streams from Push AV Server
+            # Disable SSL verification for self-signed certificates
+            with httpx.Client(verify=False, timeout=5.0) as client:
+                response = client.get(f"{push_av_server_url}/streams")
+
+                if response.status_code == 200:
+                    streams_data = response.json()
+
+                    # Send successful response
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Access-Control-Allow-Origin", "*")
+                    self.end_headers()
+                    self.wfile.write(json.dumps(streams_data).encode())
+                else:
+                    raise Exception(f"Server returned {response.status_code}")
+
+        except Exception as e:
+            logger.error(f"Error fetching streams: {e}")
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": str(e), "streams": []}).encode())
+
+    def handle_simple_proxy(self):
+        """Simplified proxy that accepts base64-encoded URLs in the path.
+
+        Format: /proxy/<base64_url>/<additional_path>
+        This allows dash.js to append paths naturally.
+        """
+        try:
+            import base64
+
+            # Extract path after /proxy/
+            path_after_proxy = self.path[len('/proxy/'):]
+
+            # Split to get base64 URL and any additional path
+            parts = path_after_proxy.split('/', 1)
+            encoded_base = parts[0]
+            extra_path = '/' + parts[1] if len(parts) > 1 else ''
+
+            # Decode base URL
+            try:
+                base_url = base64.urlsafe_b64decode(encoded_base.encode()).decode('utf-8')
+            except Exception as e:
+                logger.error(f"Failed to decode base64 URL: {e}")
+                self.send_error(400, "Invalid encoded URL")
+                return
+
+            # Construct full URL
+            stream_url = base_url.rstrip('/') + extra_path
+            logger.info(f"Simple proxy: {stream_url}")
+
+            # Fetch from upstream
+            with httpx.Client(verify=False, timeout=30.0) as client:
+                response = client.get(stream_url)
+
+                if response.status_code != 200:
+                    self.send_error(response.status_code, "Upstream error")
+                    return
+
+                content_type = response.headers.get('Content-Type', 'application/octet-stream')
+
+                # Send response
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Access-Control-Allow-Origin", "*")
+
+                content_length = response.headers.get('Content-Length')
+                if content_length:
+                    self.send_header("Content-Length", content_length)
+
+                self.end_headers()
+                self.wfile.write(response.content)
+
+        except Exception as e:
+            logger.error(f"Error in simple proxy: {e}")
+            if not self.wfile.closed:
+                self.send_error(500, f"Proxy error: {str(e)}")
+
+    def handle_stream_proxy(self):
+        """Proxy video stream from Push AV Server to avoid CORS and SSL issues."""
+        try:
+            logger.info(f"Proxy request path: {self.path}")
+
+            # Parse the full path - dash.js may append paths after the query parameter
+            # Example: /api/stream_proxy?url=<encoded_base>/media/segment_1001.m4s
+            # or: /api/stream_proxy/media/segment_1001.m4s?url=<encoded_base>
+            parsed_url = urlparse(self.path)
+
+            # Parse query parameters
+            query_params = parse_qs(parsed_url.query)
+            stream_url = query_params.get('url', [None])[0]
+
+            if not stream_url:
+                self.send_error(400, "Missing 'url' parameter")
+                return
+
+            # Check if there's additional path after /api/stream_proxy
+            # This handles when dash.js appends paths like /media/segment_1001.m4s
+            path = parsed_url.path
+            if path.startswith('/api/stream_proxy/'):
+                # Extract the extra path after /api/stream_proxy/
+                extra_path = path[len('/api/stream_proxy'):]  # e.g., /media/segment_1001.m4s
+                stream_url = stream_url.rstrip('/') + extra_path
+                logger.info(f"Appended path from URL: {extra_path}")
+
+            logger.info(f"Proxying stream from: {stream_url}")
+
+            # Fetch from Push AV Server
+            # Disable SSL verification for self-signed certificates
+            with httpx.Client(verify=False, timeout=30.0) as client:
+                response = client.get(stream_url)
+
+                if response.status_code != 200:
+                    self.send_error(response.status_code, f"Upstream error")
+                    return
+
+                content_type = response.headers.get('Content-Type', 'video/mp4')
+
+                # Check if this is an MPD manifest file
+                if stream_url.endswith('.mpd') or 'mpd' in content_type.lower():
+                    # This is a DASH manifest - rewrite URLs to use our proxy
+                    logger.info("Rewriting MPD manifest URLs")
+
+                    content = response.text
+
+                    # Log original manifest for debugging
+                    logger.debug(f"Original MPD manifest:\n{content[:500]}")
+
+                    # For DASH manifests, use simplified base64-encoded proxy
+                    # This allows dash.js to naturally append paths for segment templates
+
+                    import base64
+
+                    # Extract base URL from stream_url (the directory containing the manifest)
+                    base_url = '/'.join(stream_url.rsplit('/', 1)[:-1])  # Remove filename
+                    logger.info(f"Base URL: {base_url}")
+
+                    # Encode the base URL for use in proxy path
+                    encoded_base = base64.urlsafe_b64encode(base_url.encode()).decode('ascii')
+
+                    # Remove all existing BaseURL elements
+                    content = re.sub(r'<BaseURL>[^<]+</BaseURL>', '', content)
+
+                    # Rewrite non-template attributes (like initialization)
+                    def rewrite_media_url(match):
+                        attr_name = match.group(1)
+                        original_url = match.group(2)
+
+                        # Skip template URLs - leave them as-is, BaseURL will handle them
+                        if '$' in original_url:
+                            logger.debug(f"Preserving template: {attr_name}=\"{original_url}\"")
+                            return match.group(0)
+
+                        # For non-template URLs, make them absolute
+                        if original_url.startswith('http'):
+                            full_url = original_url
+                        else:
+                            full_url = f"{base_url}/{original_url}"
+
+                        # Use simple proxy format
+                        encoded_url = base64.urlsafe_b64encode(full_url.encode()).decode('ascii')
+                        proxied_url = f"http://192.168.20.180:8999/proxy/{encoded_url}"
+
+                        logger.debug(f"Rewriting {attr_name}=\"{original_url}\" -> \"{proxied_url}\"")
+                        return f'{attr_name}="{proxied_url}"'
+
+                    content = re.sub(r'(initialization|sourceURL)="([^"]+)"', rewrite_media_url, content)
+
+                    # Add BaseURL using the simplified proxy format
+                    # dash.js will append media template paths to this
+                    proxied_base = f"http://192.168.20.180:8999/proxy/{encoded_base}"
+
+                    # Insert BaseURL at the beginning of the first Period
+                    if '<Period>' in content:
+                        content = content.replace('<Period>', f'<Period><BaseURL>{proxied_base}/</BaseURL>', 1)
+                    elif '<MPD' in content:
+                        # Insert after MPD opening tag
+                        mpd_end = content.find('>', content.find('<MPD'))
+                        if mpd_end > 0:
+                            content = content[:mpd_end+1] + f'\n<BaseURL>{proxied_base}/</BaseURL>\n' + content[mpd_end+1:]
+
+                    logger.info(f"=== REWRITTEN MPD MANIFEST ===")
+                    logger.info(content)
+                    logger.info(f"=== END MPD MANIFEST ===")
+
+                    # Send modified manifest
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/dash+xml")
+                    self.send_header("Access-Control-Allow-Origin", "*")
+                    self.send_header("Content-Length", str(len(content.encode('utf-8'))))
+                    self.end_headers()
+                    self.wfile.write(content.encode('utf-8'))
+                    logger.info("Sent rewritten MPD manifest")
+                else:
+                    # Regular file - stream as-is
+                    self.send_response(200)
+                    self.send_header("Content-Type", content_type)
+                    self.send_header("Access-Control-Allow-Origin", "*")
+
+                    content_length = response.headers.get('Content-Length')
+                    if content_length:
+                        self.send_header("Content-Length", content_length)
+
+                    self.end_headers()
+                    self.wfile.write(response.content)
+
+        except Exception as e:
+            logger.error(f"Error proxying stream: {e}")
+            if not self.wfile.closed:
+                self.send_error(500, f"Proxy error: {str(e)}")
+
     def serve_player(self):
         """Serve a video player using external HTML template."""
         # Get dynamic data from server
         prompt_options = getattr(self.server, "prompt_options", {})
         prompt_text = getattr(self.server, "prompt_text", "Video Verification")
+        is_push_av = getattr(self.server, "is_push_av_verification", False)
+        push_av_server_url = getattr(self.server, "push_av_server_url", "https://localhost:1234")
 
         # Generate radio button options dynamically
         radio_options_html = ""
         for key, value in prompt_options.items():
             radio_options_html += f"""
             <div class="popup-radio-row" data-value="{value}" onclick="selectOption({value})">
-                <input type="radio" id="radio_{value}" name="group_1" value="{value}">
+                <div class="p-radiobutton">
+                    <div class="p-radiobutton-box">
+                        <span class="p-radiobutton-icon"></span>
+                    </div>
+                </div>
                 <label for="radio_{value}">{html.escape(key)}</label>
             </div>
             """
 
+        # Choose template based on verification type
+        if is_push_av:
+            template_filename = "push_av_stream_verification.html"
+        else:
+            template_filename = "video_verification.html"
+
         # Read HTML template from file
         try:
-            template_path = Path(__file__).parent / "video_verification.html"
+            template_path = Path(__file__).parent / template_filename
             with open(template_path, "r", encoding="utf-8") as f:
                 html_template = f.read()
 
             # Replace placeholders
             html_content = html_template.format(
-                prompt_text=html.escape(prompt_text), radio_options_html=radio_options_html
+                prompt_text=html.escape(prompt_text),
+                radio_options_html=radio_options_html,
+                push_av_server_url=html.escape(push_av_server_url)
             )
         except Exception as e:
             logger.error(f"Failed to load HTML template: {e}")
@@ -235,7 +490,16 @@ class CameraHTTPServer:
         self.server: Optional[ThreadingHTTPServer] = None
         self.server_thread: Optional[threading.Thread] = None
 
-    def start(self, mp4_queue, response_queue, video_handler, prompt_options=None, prompt_text="Video Verification"):
+    def start(
+        self,
+        mp4_queue,
+        response_queue,
+        video_handler,
+        prompt_options=None,
+        prompt_text="Video Verification",
+        is_push_av_verification=False,
+        push_av_server_url=None,
+    ):
         """Start HTTP server with required queues and data."""
         try:
             # Use ThreadingHTTPServer for better concurrency
@@ -248,9 +512,14 @@ class CameraHTTPServer:
             self.server.prompt_options = prompt_options or {}
             self.server.prompt_text = prompt_text
             self.server.video_handler = video_handler
+            self.server.is_push_av_verification = is_push_av_verification
+            self.server.push_av_server_url = push_av_server_url
 
             logger.info(f"HTTP server configured with prompt_options: {self.server.prompt_options}")
             logger.info(f"HTTP server configured with prompt_text: {self.server.prompt_text}")
+            logger.info(f"HTTP server Push AV mode: {is_push_av_verification}")
+            if push_av_server_url:
+                logger.info(f"HTTP server Push AV Server URL: {push_av_server_url}")
 
             def run_server():
                 logger.info(f"Starting HTTP video server on port {self.port}")

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -423,11 +423,7 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
         for key, value in prompt_options.items():
             radio_options_html += f"""
             <div class="popup-radio-row" data-value="{value}" onclick="selectOption({value})">
-                <div class="p-radiobutton">
-                    <div class="p-radiobutton-box">
-                        <span class="p-radiobutton-icon"></span>
-                    </div>
-                </div>
+                <input type="radio" name="option" value="{value}" id="radio_{value}">
                 <label for="radio_{value}">{html.escape(key)}</label>
             </div>
             """

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -20,7 +20,6 @@ import queue
 import re
 import threading
 import time
-import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional

--- a/th_cli/test_run/camera/camera_http_server.py
+++ b/th_cli/test_run/camera/camera_http_server.py
@@ -330,7 +330,7 @@ class VideoStreamingHandler(BaseHTTPRequestHandler):
                 response = client.get(stream_url)
 
                 if response.status_code != 200:
-                    self.send_error(response.status_code, f"Upstream error")
+                    self.send_error(response.status_code, "Upstream error")
                     return
 
                 content_type = response.headers.get("Content-Type", "video/mp4")

--- a/th_cli/test_run/camera/push_av_stream_verification.html
+++ b/th_cli/test_run/camera/push_av_stream_verification.html
@@ -250,6 +250,23 @@
             flex-wrap: wrap;
         }}
 
+        .verification-hint {{
+            background: #e3f2fd;
+            border-left: 4px solid #2196F3;
+            padding: 12px 16px;
+            margin: 12px 0;
+            border-radius: 4px;
+            font-size: 14px;
+            color: #1976d2;
+            line-height: 1.5;
+        }}
+
+        .verification-hint.warning {{
+            background: #fff3e0;
+            border-left-color: #ff9800;
+            color: #e65100;
+        }}
+
         .popup-radio-row {{
             display: flex;
             align-items: center;
@@ -497,22 +514,24 @@
 
         function displayStreams(streams) {{
             const streamsList = document.getElementById('streamsList');
-
-            console.log('displayStreams called with:', streams);
+            const hintElement = document.getElementById('verificationHint');
 
             if (!streams || streams.length === 0) {{
                 streamsList.innerHTML = '<div class="no-streams">No streams available yet.<br><small>The DUT may not have started uploading. Click "Refresh Streams" to check again.</small></div>';
+                hintElement.innerHTML = '⚠️ <strong>No streams found.</strong> If verifying that upload has stopped, this is the expected result.';
+                hintElement.className = 'verification-hint warning';
                 return;
             }}
 
-            // Store streams data globally
             streamsData = streams;
-            console.log('Stored streamsData:', streamsData);
+
+            // Clear hint when streams are available - user can see them in the list
+            hintElement.innerHTML = '';
+            hintElement.className = '';
 
             let html = '<ul class="streams-list">';
             streams.forEach((stream, index) => {{
                 const streamId = stream.id || index;
-                console.log(`Stream ${{index}}:`, stream);
                 html += `
                     <li class="stream-item" id="stream-${{index}}">
                         <a href="#" onclick="selectStream(${{index}}); return false;">
@@ -525,17 +544,15 @@
             html += '</ul>';
             streamsList.innerHTML = html;
 
-            // Auto-select first stream
-            if (streams.length > 0) {{
-                console.log('Auto-selecting first stream');
-                setTimeout(() => selectStream(0), 100);
-            }}
+            // Don't auto-select - wait for user to click a stream
+            // Hide the contents panels until user selects a stream
+            const streamContentsSection = document.getElementById('streamContentsSection');
+            const nonConformingSection = document.getElementById('nonConformingSection');
+            streamContentsSection.style.display = 'none';
+            nonConformingSection.style.display = 'none';
         }}
 
         function selectStream(index) {{
-            console.log('selectStream called with index:', index);
-            console.log('Current streamsData:', streamsData);
-
             if (!streamsData || !streamsData[index]) {{
                 console.error('Stream data not found for index:', index);
                 return;
@@ -543,11 +560,9 @@
 
             const stream = streamsData[index];
             selectedStreamId = stream.id || index;
-            console.log('Selected stream:', stream);
 
             // Combine valid_files and invalid_files (or use files if present)
             const allFiles = stream.files || [...(stream.valid_files || []), ...(stream.invalid_files || [])];
-            console.log('All files:', allFiles);
 
             // Update selected styling
             document.querySelectorAll('.stream-item').forEach(item => {{
@@ -556,83 +571,54 @@
             document.getElementById(`stream-${{index}}`).classList.add('selected');
 
             // Display stream contents
-            console.log('Calling displayStreamContents...');
             displayStreamContents(stream);
 
             // Play the video - look for MPD manifest first, then segment files
             if (allFiles && allFiles.length > 0) {{
-                // Convert files to strings
                 const fileStrings = allFiles.map(f => String(f));
-                console.log('File strings:', fileStrings);
 
                 // Try to find MPD manifest (DASH/CMAF format)
                 let videoFile = fileStrings.find(f => f.includes('.mpd'));
-                console.log('MPD file:', videoFile);
 
                 // If no MPD, try to find first segment file
                 if (!videoFile) {{
                     videoFile = fileStrings.find(f => f.includes('.m4s') || f.includes('segment'));
-                    console.log('Segment file:', videoFile);
                 }}
 
                 // If still no file, try any media file
                 if (!videoFile) {{
                     videoFile = fileStrings.find(f => f.includes('.mp4') || f.includes('media'));
-                    console.log('Media file:', videoFile);
                 }}
 
                 if (videoFile) {{
                     const videoUrl = `${{pushAvServerUrl}}/streams/${{stream.id}}/${{videoFile}}`;
-                    console.log('Playing video from:', videoUrl);
                     playStream(videoUrl);
-                }} else {{
-                    console.warn('No playable video file found in stream');
                 }}
-            }} else {{
-                console.warn('Stream has no files');
             }}
         }}
 
         function displayStreamContents(stream) {{
-            console.log('displayStreamContents called with stream:', stream);
-
             const streamContentsSection = document.getElementById('streamContentsSection');
             const streamContents = document.getElementById('streamContents');
             const streamContentsTitle = document.getElementById('streamContentsTitle');
             const nonConformingSection = document.getElementById('nonConformingSection');
             const nonConformingContent = document.getElementById('nonConformingContent');
 
-            console.log('DOM elements:', {{
-                streamContentsSection,
-                streamContents,
-                streamContentsTitle,
-                nonConformingSection,
-                nonConformingContent
-            }});
-
             // Update title
             const streamNum = parseInt(stream.id) + 1;
             streamContentsTitle.textContent = `Stream ${{streamNum}} Contents`;
-            console.log('Set title to:', streamContentsTitle.textContent);
 
             // Combine valid and invalid files (or use files if present)
             const validFiles = stream.valid_files || [];
             const invalidFiles = stream.invalid_files || [];
             const allFiles = stream.files || [...validFiles, ...invalidFiles];
 
-            console.log('Valid files:', validFiles);
-            console.log('Invalid files:', invalidFiles);
-            console.log('All files:', allFiles);
-
             // Display files
             if (allFiles && allFiles.length > 0) {{
-                console.log('Stream has', allFiles.length, 'files');
                 let html = '';
                 allFiles.forEach((file, index) => {{
-                    // Convert file to string (in case it's a Path object)
                     const fileName = String(file);
                     const fileUrl = `${{pushAvServerUrl}}/streams/${{stream.id}}/${{fileName}}`;
-                    console.log(`File ${{index}}: ${{fileName}}`);
                     html += `
                         <div class="stream-file-item">
                             <div class="stream-file-name">
@@ -645,46 +631,101 @@
                 }});
                 streamContents.innerHTML = html;
                 streamContentsSection.style.display = 'block';
-                console.log('Stream contents section displayed');
             }} else {{
-                console.warn('No files in stream, hiding section');
                 streamContentsSection.style.display = 'none';
             }}
 
             // Display conformance status
             if (invalidFiles.length > 0) {{
-                // Show invalid files
                 nonConformingContent.innerHTML = `<div style="color: #c62828; text-align: center;">Found ${{invalidFiles.length}} non-conforming file(s)</div>`;
             }} else {{
-                // All files conform
                 nonConformingContent.innerHTML = '<div class="conforming-message">All files conform to Matter Spec.</div>';
             }}
             nonConformingSection.style.display = 'block';
-            console.log('Non-conforming section displayed');
         }}
+
+        let currentDashPlayer = null;  // Track current player instance
 
         function playStream(streamUrl) {{
             const videoWrapper = document.getElementById('videoWrapper');
 
-            console.log('Attempting to play stream:', streamUrl);
+            // Clean up previous player instance
+            if (currentDashPlayer) {{
+                try {{
+                    currentDashPlayer.pause();
+                    currentDashPlayer.reset();
+                }} catch (e) {{
+                    // Ignore cleanup errors
+                }}
+                currentDashPlayer = null;
+            }}
+
+            // Clear any existing video element
+            const oldVideo = document.getElementById('dashPlayer');
+            if (oldVideo) {{
+                try {{
+                    oldVideo.pause();
+                    oldVideo.src = '';
+                    oldVideo.load();
+                }} catch (e) {{
+                    // Ignore cleanup errors
+                }}
+            }}
 
             if (streamUrl.includes('.mpd')) {{
-                // MPD files - use our proxy to avoid SSL certificate issues
-                console.log('Using dash.js for DASH/CMAF stream via proxy');
-
-                // Use our local proxy to avoid CORS and SSL issues
+                // MPD files - use DASH player with proxy
                 const proxyUrl = `/api/stream_proxy?url=${{encodeURIComponent(streamUrl)}}`;
-
                 videoWrapper.innerHTML = '<video id="dashPlayer" class="video-player" controls autoplay></video>';
 
                 const video = document.getElementById('dashPlayer');
                 const player = dashjs.MediaPlayer().create();
+                currentDashPlayer = player;
 
-                // Use the proxied URL
-                player.initialize(video, proxyUrl, true);
+                let hasPlayedContent = false;
+                let errorCount = 0;
+                let initializationComplete = false;
+                let fragmentsLoaded = 0;
+                let allowErrorMessages = false;
 
-                player.on(dashjs.MediaPlayer.events.ERROR, function(e) {{
-                    console.error('DASH player error:', e);
+                // Give player 2 seconds to initialize before allowing error messages
+                setTimeout(() => {{
+                    allowErrorMessages = true;
+                    if (!hasPlayedContent && !initializationComplete && errorCount > 0) {{
+                        showErrorMessage();
+                    }}
+                }}, 2000);
+
+                // Register event handlers before initialization
+                player.on(dashjs.MediaPlayer.events.PLAYBACK_STARTED, function() {{
+                    hasPlayedContent = true;
+                }});
+
+                player.on(dashjs.MediaPlayer.events.PLAYBACK_TIME_UPDATED, function(e) {{
+                    if (e.time > 0) {{
+                        hasPlayedContent = true;
+                    }}
+                }});
+
+                player.on(dashjs.MediaPlayer.events.STREAM_INITIALIZED, function() {{
+                    initializationComplete = true;
+                }});
+
+                player.on(dashjs.MediaPlayer.events.FRAGMENT_LOADING_COMPLETED, function(e) {{
+                    fragmentsLoaded++;
+                    if (!hasPlayedContent) {{
+                        hasPlayedContent = true;
+                    }}
+                }});
+
+                player.on(dashjs.MediaPlayer.events.CAN_PLAY, function() {{
+                    hasPlayedContent = true;
+                }});
+
+                player.on(dashjs.MediaPlayer.events.PLAYBACK_PLAYING, function() {{
+                    hasPlayedContent = true;
+                }});
+
+                function showErrorMessage() {{
                     videoWrapper.innerHTML = `
                         <div class="video-placeholder">
                             <span class="pi-video">📹</span>
@@ -702,12 +743,19 @@
                             </div>
                         </div>
                     `;
+                }}
+
+                player.on(dashjs.MediaPlayer.events.ERROR, function(e) {{
+                    errorCount++;
+                    // Always suppress errors for Push AV verification
+                    // Missing segments are expected when DUT stops uploading
+                    return;
                 }});
 
-                console.log('DASH player initialized with proxy URL:', proxyUrl);
+                // Initialize the player
+                player.initialize(video, proxyUrl, true);
             }} else {{
-                // Regular video files - try direct playback
-                console.log('Using HTML5 video for regular file');
+                // Regular video files - use HTML5 video
                 const proxyUrl = `/api/stream_proxy?url=${{encodeURIComponent(streamUrl)}}`;
                 videoWrapper.innerHTML = `
                     <video class="video-player" controls autoplay>
@@ -757,6 +805,11 @@
 
         // Auto-refresh streams on load
         window.onload = function() {{
+            // Set initial hint
+            const hintElement = document.getElementById('verificationHint');
+            hintElement.innerHTML = '💡 Click "Refresh Streams" to check for available streams.';
+            hintElement.className = 'verification-hint';
+
             refreshStreams();
         }};
     </script>
@@ -771,11 +824,11 @@
         <div class="p-dialog">
             <div class="p-dialog-header">
                 <span class="p-dialog-title">Push AV Stream Verification</span>
-                <small style="color: #999; font-size: 10px; margin-left: 10px;">v2.0</small>
             </div>
 
             <div class="p-dialog-content">
                 <div class="subheader">{prompt_text}</div>
+                <div id="verificationHint" class="verification-hint"></div>
 
                 <button id="refreshBtn" class="p-button" onclick="refreshStreams()">
                     <span class="p-button-icon-left pi-refresh">↻</span>

--- a/th_cli/test_run/camera/push_av_stream_verification.html
+++ b/th_cli/test_run/camera/push_av_stream_verification.html
@@ -1,0 +1,844 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Push AV Stream Verification</title>
+    <script src="https://cdn.dashjs.org/latest/dash.all.min.js"></script>
+    <style>
+        body {{
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f5f5f5;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }}
+
+        .matter-header {{
+            background: white;
+            border-bottom: 1px solid #e0e0e0;
+            padding: 12px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+
+        .header-title {{
+            font-size: 18px;
+            font-weight: 600;
+            color: #333;
+        }}
+
+        .cli-indicator {{
+            background: #2196F3;
+            color: white;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 500;
+        }}
+
+        .main-content {{
+            flex: 1;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+        }}
+
+        .p-dialog {{
+            background: white;
+            border-radius: 6px;
+            box-shadow: 0 11px 15px -7px rgba(0,0,0,.2), 0 24px 38px 3px rgba(0,0,0,.14), 0 9px 46px 8px rgba(0,0,0,.12);
+            max-width: 900px;
+            width: 100%;
+            margin: 20px;
+        }}
+
+        .p-dialog-header {{
+            padding: 1.5rem;
+            border-bottom: 1px solid #dee2e6;
+            background: #fafafa;
+            border-radius: 6px 6px 0 0;
+        }}
+
+        .p-dialog-title {{
+            font-size: 1.25rem;
+            font-weight: 700;
+        }}
+
+        .p-dialog-content {{
+            padding: 1.5rem;
+            background: #ffffff;
+            border-radius: 0 0 6px 6px;
+        }}
+
+        .subheader {{
+            font-size: 14px;
+            color: #495057;
+            margin-bottom: 1rem;
+            line-height: 1.5;
+        }}
+
+        .p-button {{
+            color: #ffffff;
+            background: #22c55e;
+            border: 1px solid #22c55e;
+            padding: 0.5rem 1rem;
+            font-size: 1rem;
+            transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+            border-radius: 6px;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }}
+
+        .p-button:hover:not(:disabled) {{
+            background: #16a34a;
+            border-color: #16a34a;
+        }}
+
+        .p-button:disabled {{
+            opacity: 0.6;
+            cursor: not-allowed;
+        }}
+
+        .p-button-icon-left {{
+            margin-right: 0.5rem;
+        }}
+
+        .pi {{
+            font-family: 'primeicons';
+        }}
+
+        .pi-refresh:before {{
+            content: "↻";
+            font-size: 1.2em;
+        }}
+
+        .pi-play-circle:before {{
+            content: "▶";
+        }}
+
+        .pi-video:before {{
+            content: "📹";
+        }}
+
+        .streams-list-container {{
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+            background: white;
+        }}
+
+        .streams-list-header {{
+            padding: 0.75rem 1rem;
+            background: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+            font-weight: 600;
+            font-size: 14px;
+            color: #495057;
+        }}
+
+        .streams-list {{
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            max-height: 200px;
+            overflow-y: auto;
+        }}
+
+        .stream-item {{
+            border-bottom: 1px solid #dee2e6;
+        }}
+
+        .stream-item:last-child {{
+            border-bottom: none;
+        }}
+
+        .stream-item a {{
+            display: flex;
+            align-items: center;
+            padding: 0.75rem 1rem;
+            text-decoration: none;
+            color: #495057;
+            transition: background-color 0.2s;
+            gap: 0.5rem;
+        }}
+
+        .stream-item a:hover {{
+            background: #f8f9fa;
+        }}
+
+        .stream-item.selected a {{
+            background: #e3f2fd;
+            color: #2196F3;
+            font-weight: 600;
+        }}
+
+        .no-streams {{
+            padding: 2rem;
+            text-align: center;
+            color: #6c757d;
+        }}
+
+        .loading {{
+            padding: 2rem;
+            text-align: center;
+            color: #6c757d;
+        }}
+
+        .video-player-container {{
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+            background: white;
+        }}
+
+        .video-player-header {{
+            padding: 0.75rem 1rem;
+            background: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+            font-weight: 600;
+            font-size: 14px;
+            color: #495057;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }}
+
+        .video-player-wrapper {{
+            position: relative;
+            background: #000;
+            min-height: 360px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }}
+
+        .video-player {{
+            width: 100%;
+            max-height: 480px;
+            display: block;
+        }}
+
+        .video-placeholder {{
+            position: absolute;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+            color: #6c757d;
+        }}
+
+        .video-placeholder .pi {{
+            font-size: 3rem;
+        }}
+
+        .input-items-div {{
+            margin: 1rem 0;
+        }}
+
+        .popup-radio-div {{
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+            flex-wrap: wrap;
+        }}
+
+        .popup-radio-row {{
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 1rem;
+            border: 1px solid #ced4da;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: all 0.2s;
+        }}
+
+        .popup-radio-row:hover {{
+            background: #f8f9fa;
+            border-color: #2196F3;
+        }}
+
+        .popup-radio-row.selected {{
+            background: #e3f2fd;
+            border-color: #2196F3;
+        }}
+
+        .p-radiobutton {{
+            width: 20px;
+            height: 20px;
+            position: relative;
+        }}
+
+        .p-radiobutton-box {{
+            width: 20px;
+            height: 20px;
+            border: 2px solid #ced4da;
+            background: white;
+            border-radius: 50%;
+            transition: background-color 0.2s, border-color 0.2s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }}
+
+        .popup-radio-row.selected .p-radiobutton-box {{
+            border-color: #2196F3;
+            background: white;
+        }}
+
+        .p-radiobutton-icon {{
+            width: 10px;
+            height: 10px;
+            background: #2196F3;
+            border-radius: 50%;
+            opacity: 0;
+            transition: opacity 0.2s;
+        }}
+
+        .popup-radio-row.selected .p-radiobutton-icon {{
+            opacity: 1;
+        }}
+
+        input[type="radio"] {{
+            display: none;
+        }}
+
+        label {{
+            font-weight: 500;
+            color: #495057;
+            cursor: pointer;
+            font-size: 14px;
+        }}
+
+        .buttons-div {{
+            text-align: center;
+            margin-top: 1.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid #dee2e6;
+        }}
+
+        .popup-button {{
+            background: #2196F3;
+            color: white;
+            border: 1px solid #2196F3;
+            padding: 0.75rem 1.5rem;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s;
+        }}
+
+        .popup-button:hover:not(:disabled) {{
+            background: #1976D2;
+            border-color: #1976D2;
+        }}
+
+        .popup-button:disabled {{
+            background: #ced4da;
+            border-color: #ced4da;
+            cursor: not-allowed;
+            opacity: 0.6;
+        }}
+
+        .error-message {{
+            background: #fee;
+            border-left: 4px solid #f44336;
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 4px;
+            color: #c62828;
+        }}
+
+        .stream-contents-container {{
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            background: white;
+        }}
+
+        .stream-contents-header {{
+            padding: 0.75rem 1rem;
+            background: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+            font-weight: 600;
+            font-size: 14px;
+            color: #495057;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }}
+
+        .stream-contents-list {{
+            padding: 1rem;
+        }}
+
+        .stream-file-item {{
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.5rem 0;
+            border-bottom: 1px solid #f0f0f0;
+        }}
+
+        .stream-file-item:last-child {{
+            border-bottom: none;
+        }}
+
+        .stream-file-name {{
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: #495057;
+            font-size: 14px;
+        }}
+
+        .stream-file-link {{
+            color: #2196F3;
+            text-decoration: none;
+            font-size: 12px;
+            font-weight: 500;
+        }}
+
+        .stream-file-link:hover {{
+            text-decoration: underline;
+        }}
+
+        .non-conforming-container {{
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            background: #ffebee;
+        }}
+
+        .non-conforming-header {{
+            padding: 0.75rem 1rem;
+            background: #ffcdd2;
+            border-bottom: 1px solid #ef9a9a;
+            font-weight: 600;
+            font-size: 14px;
+            color: #c62828;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }}
+
+        .non-conforming-content {{
+            padding: 1rem;
+            text-align: center;
+            color: #2e7d32;
+            background: #ffebee;
+        }}
+
+        .conforming-message {{
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            color: #2e7d32;
+            font-size: 14px;
+        }}
+
+        .conforming-message::before {{
+            content: "✓";
+            font-size: 1.2em;
+            font-weight: bold;
+            color: #2e7d32;
+        }}
+    </style>
+    <script>
+        let selectedValue = null;
+        let selectedStreamId = null;
+        let pushAvServerUrl = '{push_av_server_url}';
+        let streamsData = []; // Store full stream data with files
+
+        function selectOption(value) {{
+            selectedValue = value;
+            document.querySelectorAll('.popup-radio-row').forEach(row => {{
+                row.classList.remove('selected');
+            }});
+            const selectedRow = document.querySelector(`[data-value="${{value}}"]`);
+            if (selectedRow) {{
+                selectedRow.classList.add('selected');
+            }}
+            document.getElementById('submitBtn').disabled = false;
+        }}
+
+        async function refreshStreams() {{
+            const button = document.getElementById('refreshBtn');
+            const streamsList = document.getElementById('streamsList');
+
+            button.disabled = true;
+            button.innerHTML = '<span class="p-button-icon-left pi-refresh">↻</span><span>Refreshing...</span>';
+            streamsList.innerHTML = '<div class="loading">Loading streams...</div>';
+
+            try {{
+                const response = await fetch('/api/streams');
+                if (!response.ok) {{
+                    throw new Error(`HTTP error! status: ${{response.status}}`);
+                }}
+
+                const data = await response.json();
+                displayStreams(data.streams || []);
+            }} catch (error) {{
+                console.error('Error fetching streams:', error);
+                streamsList.innerHTML = `<div class="error-message">Failed to load streams: ${{error.message}}<br><small>Make sure the Push AV Server is running at ${{pushAvServerUrl}}</small></div>`;
+            }} finally {{
+                button.disabled = false;
+                button.innerHTML = '<span class="p-button-icon-left pi-refresh">↻</span><span>Refresh Streams</span>';
+            }}
+        }}
+
+        function displayStreams(streams) {{
+            const streamsList = document.getElementById('streamsList');
+
+            console.log('displayStreams called with:', streams);
+
+            if (!streams || streams.length === 0) {{
+                streamsList.innerHTML = '<div class="no-streams">No streams available yet.<br><small>The DUT may not have started uploading. Click "Refresh Streams" to check again.</small></div>';
+                return;
+            }}
+
+            // Store streams data globally
+            streamsData = streams;
+            console.log('Stored streamsData:', streamsData);
+
+            let html = '<ul class="streams-list">';
+            streams.forEach((stream, index) => {{
+                const streamId = stream.id || index;
+                console.log(`Stream ${{index}}:`, stream);
+                html += `
+                    <li class="stream-item" id="stream-${{index}}">
+                        <a href="#" onclick="selectStream(${{index}}); return false;">
+                            <span class="pi-play-circle">▶</span>
+                            <span>Stream ${{parseInt(streamId) + 1}}</span>
+                        </a>
+                    </li>
+                `;
+            }});
+            html += '</ul>';
+            streamsList.innerHTML = html;
+
+            // Auto-select first stream
+            if (streams.length > 0) {{
+                console.log('Auto-selecting first stream');
+                setTimeout(() => selectStream(0), 100);
+            }}
+        }}
+
+        function selectStream(index) {{
+            console.log('selectStream called with index:', index);
+            console.log('Current streamsData:', streamsData);
+
+            if (!streamsData || !streamsData[index]) {{
+                console.error('Stream data not found for index:', index);
+                return;
+            }}
+
+            const stream = streamsData[index];
+            selectedStreamId = stream.id || index;
+            console.log('Selected stream:', stream);
+
+            // Combine valid_files and invalid_files (or use files if present)
+            const allFiles = stream.files || [...(stream.valid_files || []), ...(stream.invalid_files || [])];
+            console.log('All files:', allFiles);
+
+            // Update selected styling
+            document.querySelectorAll('.stream-item').forEach(item => {{
+                item.classList.remove('selected');
+            }});
+            document.getElementById(`stream-${{index}}`).classList.add('selected');
+
+            // Display stream contents
+            console.log('Calling displayStreamContents...');
+            displayStreamContents(stream);
+
+            // Play the video - look for MPD manifest first, then segment files
+            if (allFiles && allFiles.length > 0) {{
+                // Convert files to strings
+                const fileStrings = allFiles.map(f => String(f));
+                console.log('File strings:', fileStrings);
+
+                // Try to find MPD manifest (DASH/CMAF format)
+                let videoFile = fileStrings.find(f => f.includes('.mpd'));
+                console.log('MPD file:', videoFile);
+
+                // If no MPD, try to find first segment file
+                if (!videoFile) {{
+                    videoFile = fileStrings.find(f => f.includes('.m4s') || f.includes('segment'));
+                    console.log('Segment file:', videoFile);
+                }}
+
+                // If still no file, try any media file
+                if (!videoFile) {{
+                    videoFile = fileStrings.find(f => f.includes('.mp4') || f.includes('media'));
+                    console.log('Media file:', videoFile);
+                }}
+
+                if (videoFile) {{
+                    const videoUrl = `${{pushAvServerUrl}}/streams/${{stream.id}}/${{videoFile}}`;
+                    console.log('Playing video from:', videoUrl);
+                    playStream(videoUrl);
+                }} else {{
+                    console.warn('No playable video file found in stream');
+                }}
+            }} else {{
+                console.warn('Stream has no files');
+            }}
+        }}
+
+        function displayStreamContents(stream) {{
+            console.log('displayStreamContents called with stream:', stream);
+
+            const streamContentsSection = document.getElementById('streamContentsSection');
+            const streamContents = document.getElementById('streamContents');
+            const streamContentsTitle = document.getElementById('streamContentsTitle');
+            const nonConformingSection = document.getElementById('nonConformingSection');
+            const nonConformingContent = document.getElementById('nonConformingContent');
+
+            console.log('DOM elements:', {{
+                streamContentsSection,
+                streamContents,
+                streamContentsTitle,
+                nonConformingSection,
+                nonConformingContent
+            }});
+
+            // Update title
+            const streamNum = parseInt(stream.id) + 1;
+            streamContentsTitle.textContent = `Stream ${{streamNum}} Contents`;
+            console.log('Set title to:', streamContentsTitle.textContent);
+
+            // Combine valid and invalid files (or use files if present)
+            const validFiles = stream.valid_files || [];
+            const invalidFiles = stream.invalid_files || [];
+            const allFiles = stream.files || [...validFiles, ...invalidFiles];
+
+            console.log('Valid files:', validFiles);
+            console.log('Invalid files:', invalidFiles);
+            console.log('All files:', allFiles);
+
+            // Display files
+            if (allFiles && allFiles.length > 0) {{
+                console.log('Stream has', allFiles.length, 'files');
+                let html = '';
+                allFiles.forEach((file, index) => {{
+                    // Convert file to string (in case it's a Path object)
+                    const fileName = String(file);
+                    const fileUrl = `${{pushAvServerUrl}}/streams/${{stream.id}}/${{fileName}}`;
+                    console.log(`File ${{index}}: ${{fileName}}`);
+                    html += `
+                        <div class="stream-file-item">
+                            <div class="stream-file-name">
+                                <span class="pi">📄</span>
+                                <span>${{fileName}}</span>
+                            </div>
+                            <a href="${{fileUrl}}" target="_blank" class="stream-file-link">#${{index + 1}}</a>
+                        </div>
+                    `;
+                }});
+                streamContents.innerHTML = html;
+                streamContentsSection.style.display = 'block';
+                console.log('Stream contents section displayed');
+            }} else {{
+                console.warn('No files in stream, hiding section');
+                streamContentsSection.style.display = 'none';
+            }}
+
+            // Display conformance status
+            if (invalidFiles.length > 0) {{
+                // Show invalid files
+                nonConformingContent.innerHTML = `<div style="color: #c62828; text-align: center;">Found ${{invalidFiles.length}} non-conforming file(s)</div>`;
+            }} else {{
+                // All files conform
+                nonConformingContent.innerHTML = '<div class="conforming-message">All files conform to Matter Spec.</div>';
+            }}
+            nonConformingSection.style.display = 'block';
+            console.log('Non-conforming section displayed');
+        }}
+
+        function playStream(streamUrl) {{
+            const videoWrapper = document.getElementById('videoWrapper');
+
+            console.log('Attempting to play stream:', streamUrl);
+
+            if (streamUrl.includes('.mpd')) {{
+                // MPD files - use our proxy to avoid SSL certificate issues
+                console.log('Using dash.js for DASH/CMAF stream via proxy');
+
+                // Use our local proxy to avoid CORS and SSL issues
+                const proxyUrl = `/api/stream_proxy?url=${{encodeURIComponent(streamUrl)}}`;
+
+                videoWrapper.innerHTML = '<video id="dashPlayer" class="video-player" controls autoplay></video>';
+
+                const video = document.getElementById('dashPlayer');
+                const player = dashjs.MediaPlayer().create();
+
+                // Use the proxied URL
+                player.initialize(video, proxyUrl, true);
+
+                player.on(dashjs.MediaPlayer.events.ERROR, function(e) {{
+                    console.error('DASH player error:', e);
+                    videoWrapper.innerHTML = `
+                        <div class="video-placeholder">
+                            <span class="pi-video">📹</span>
+                            <div style="text-align: center; padding: 20px; color: #c62828;">
+                                <p>Error loading DASH stream</p>
+                                <p style="font-size: 12px;">The stream manifest is available but cannot be played.</p>
+                                <p style="font-size: 11px; color: #666; margin-top: 15px;">
+                                    Stream details:<br>
+                                    <a href="${{streamUrl}}" target="_blank" style="color: #2196F3;">View MPD Manifest</a>
+                                </p>
+                                <p style="font-size: 11px; color: #888; margin-top: 10px;">
+                                    Note: The DUT is successfully uploading to the Push AV Server.<br>
+                                    Check the "Stream Contents" section below for uploaded files.
+                                </p>
+                            </div>
+                        </div>
+                    `;
+                }});
+
+                console.log('DASH player initialized with proxy URL:', proxyUrl);
+            }} else {{
+                // Regular video files - try direct playback
+                console.log('Using HTML5 video for regular file');
+                const proxyUrl = `/api/stream_proxy?url=${{encodeURIComponent(streamUrl)}}`;
+                videoWrapper.innerHTML = `
+                    <video class="video-player" controls autoplay>
+                        <source src="${{proxyUrl}}" type="video/mp4">
+                        Your browser does not support the video tag.
+                    </video>
+                `;
+            }}
+        }}
+
+        async function submitResponse() {{
+            if (selectedValue) {{
+                const button = document.getElementById('submitBtn');
+                button.disabled = true;
+                button.textContent = 'Submitting...';
+
+                try {{
+                    const response = await fetch('/submit_response', {{
+                        method: 'POST',
+                        headers: {{
+                            'Content-Type': 'application/json',
+                        }},
+                        body: JSON.stringify({{ response: selectedValue }})
+                    }});
+
+                    if (response.ok) {{
+                        button.textContent = 'Response Sent!';
+                        button.style.background = '#22c55e';
+                        setTimeout(() => {{
+                            button.textContent = 'Complete';
+                        }}, 1000);
+                    }} else {{
+                        throw new Error(`Server error: ${{response.status}}`);
+                    }}
+                }} catch (error) {{
+                    console.error('Error submitting response:', error);
+                    button.textContent = 'Error - Try Again';
+                    button.style.background = '#f44336';
+                    button.disabled = false;
+                    setTimeout(() => {{
+                        button.textContent = 'Submit';
+                        button.style.background = '#2196F3';
+                    }}, 3000);
+                }}
+            }}
+        }}
+
+        // Auto-refresh streams on load
+        window.onload = function() {{
+            refreshStreams();
+        }};
+    </script>
+</head>
+<body>
+    <div class="matter-header">
+        <div class="header-title">Matter Certification Tool</div>
+        <div class="cli-indicator">CLI</div>
+    </div>
+
+    <div class="main-content">
+        <div class="p-dialog">
+            <div class="p-dialog-header">
+                <span class="p-dialog-title">Push AV Stream Verification</span>
+                <small style="color: #999; font-size: 10px; margin-left: 10px;">v2.0</small>
+            </div>
+
+            <div class="p-dialog-content">
+                <div class="subheader">{prompt_text}</div>
+
+                <button id="refreshBtn" class="p-button" onclick="refreshStreams()">
+                    <span class="p-button-icon-left pi-refresh">↻</span>
+                    <span>Refresh Streams</span>
+                </button>
+
+                <div class="streams-list-container">
+                    <div class="streams-list-header">Available Streams</div>
+                    <div id="streamsList">
+                        <div class="loading">Click "Refresh Streams" to load</div>
+                    </div>
+                </div>
+
+                <div class="video-player-container">
+                    <div class="video-player-header">
+                        <span class="pi-play-circle">▶</span>
+                        <span>Video Player</span>
+                    </div>
+                    <div class="video-player-wrapper" id="videoWrapper">
+                        <div class="video-placeholder">
+                            <span class="pi-video">📹</span>
+                            <span>Select a stream to play video</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Stream Contents Section -->
+                <div id="streamContentsSection" style="display: none; margin-bottom: 1rem;">
+                    <div class="stream-contents-container">
+                        <div class="stream-contents-header">
+                            <span class="pi">📄</span>
+                            <span id="streamContentsTitle">Stream Contents</span>
+                        </div>
+                        <div id="streamContents" class="stream-contents-list">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Non-Conforming Files Section -->
+                <div id="nonConformingSection" style="display: none; margin-bottom: 1rem;">
+                    <div class="non-conforming-container">
+                        <div class="non-conforming-header">
+                            <span class="pi">⚠️</span>
+                            <span>Non-Conforming Files</span>
+                        </div>
+                        <div id="nonConformingContent" class="non-conforming-content">
+                        </div>
+                    </div>
+                </div>
+
+                <div class="input-items-div">
+                    <div class="popup-radio-div">
+                        {radio_options_html}
+                    </div>
+                </div>
+
+                <div class="buttons-div">
+                    <button id="submitBtn" class="popup-button" onclick="submitResponse()" disabled>
+                        Submit
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/th_cli/test_run/camera/push_av_stream_verification.html
+++ b/th_cli/test_run/camera/push_av_stream_verification.html
@@ -245,8 +245,9 @@
 
         .popup-radio-div {{
             display: flex;
-            gap: 1rem;
+            gap: 20px;
             justify-content: center;
+            margin: 20px 0;
             flex-wrap: wrap;
         }}
 
@@ -270,16 +271,18 @@
         .popup-radio-row {{
             display: flex;
             align-items: center;
-            gap: 0.5rem;
-            padding: 0.5rem 1rem;
-            border: 1px solid #ced4da;
-            border-radius: 6px;
+            gap: 8px;
+            padding: 10px 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
             cursor: pointer;
             transition: all 0.2s;
+            min-width: 100px;
+            justify-content: center;
         }}
 
         .popup-radio-row:hover {{
-            background: #f8f9fa;
+            background: #f0f0f0;
             border-color: #2196F3;
         }}
 
@@ -288,49 +291,14 @@
             border-color: #2196F3;
         }}
 
-        .p-radiobutton {{
-            width: 20px;
-            height: 20px;
-            position: relative;
-        }}
-
-        .p-radiobutton-box {{
-            width: 20px;
-            height: 20px;
-            border: 2px solid #ced4da;
-            background: white;
-            border-radius: 50%;
-            transition: background-color 0.2s, border-color 0.2s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }}
-
-        .popup-radio-row.selected .p-radiobutton-box {{
-            border-color: #2196F3;
-            background: white;
-        }}
-
-        .p-radiobutton-icon {{
-            width: 10px;
-            height: 10px;
-            background: #2196F3;
-            border-radius: 50%;
-            opacity: 0;
-            transition: opacity 0.2s;
-        }}
-
-        .popup-radio-row.selected .p-radiobutton-icon {{
-            opacity: 1;
-        }}
-
         input[type="radio"] {{
-            display: none;
+            margin-right: 8px;
+            transform: scale(1.2);
         }}
 
         label {{
             font-weight: 500;
-            color: #495057;
+            color: #333;
             cursor: pointer;
             font-size: 14px;
         }}
@@ -477,13 +445,19 @@
 
         function selectOption(value) {{
             selectedValue = value;
+
+            // Update visual selection
             document.querySelectorAll('.popup-radio-row').forEach(row => {{
                 row.classList.remove('selected');
             }});
-            const selectedRow = document.querySelector(`[data-value="${{value}}"]`);
-            if (selectedRow) {{
-                selectedRow.classList.add('selected');
-            }}
+            document.querySelector(`[data-value="${{value}}"]`).classList.add('selected');
+
+            // Update radio buttons
+            document.querySelectorAll('input[type="radio"]').forEach(radio => {{
+                radio.checked = radio.value === value.toString();
+            }});
+
+            // Enable submit button
             document.getElementById('submitBtn').disabled = false;
         }}
 
@@ -492,7 +466,7 @@
             const streamsList = document.getElementById('streamsList');
 
             button.disabled = true;
-            button.innerHTML = '<span class="p-button-icon-left pi-refresh">↻</span><span>Refreshing...</span>';
+            button.innerHTML = '<span>Refreshing...</span>';
             streamsList.innerHTML = '<div class="loading">Loading streams...</div>';
 
             try {{
@@ -508,7 +482,7 @@
                 streamsList.innerHTML = `<div class="error-message">Failed to load streams: ${{error.message}}<br><small>Make sure the Push AV Server is running at ${{pushAvServerUrl}}</small></div>`;
             }} finally {{
                 button.disabled = false;
-                button.innerHTML = '<span class="p-button-icon-left pi-refresh">↻</span><span>Refresh Streams</span>';
+                button.innerHTML = '<span>Refresh Streams</span>';
             }}
         }}
 
@@ -831,7 +805,6 @@
                 <div id="verificationHint" class="verification-hint"></div>
 
                 <button id="refreshBtn" class="p-button" onclick="refreshStreams()">
-                    <span class="p-button-icon-left pi-refresh">↻</span>
                     <span>Refresh Streams</span>
                 </button>
 

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -25,14 +25,13 @@ from typing import Any, Union
 import aioconsole
 import click
 import httpx
-
-# from loguru import logger
 from websockets.client import WebSocketClientProtocol
 
 from th_cli.colorize import colorize_error, colorize_key_value, italic
 from th_cli.config import config
 from th_cli.shared_constants import MessageKeysEnum, MessageTypeEnum
 
+from .camera.camera_http_server import CameraHTTPServer
 from .socket_schemas import (
     ImageVerificationPromptRequest,
     MessagePromptRequest,
@@ -75,7 +74,7 @@ async def handle_prompt(socket: WebSocketClientProtocol, request: PromptRequest,
     if message_type == MessageTypeEnum.IMAGE_VERIFICATION_REQUEST or isinstance(
         request, ImageVerificationPromptRequest
     ):
-        await __handle_image_verification_prompt(socket=socket, prompt=request)
+        await _handle_image_verification_prompt(socket=socket, prompt=request)
     elif message_type == MessageTypeEnum.STREAM_VERIFICATION_REQUEST or isinstance(
         request, StreamVerificationPromptRequest
     ):
@@ -83,7 +82,7 @@ async def handle_prompt(socket: WebSocketClientProtocol, request: PromptRequest,
     elif message_type == MessageTypeEnum.PUSH_AV_STREAM_VERIFICATION_REQUEST or isinstance(
         request, PushAVStreamVerificationRequest
     ):
-        await __handle_push_av_stream_prompt(socket=socket, prompt=request)
+        await _handle_push_av_stream_prompt(socket=socket, prompt=request)
     elif message_type == MessageTypeEnum.MESSAGE_REQUEST or isinstance(request, MessagePromptRequest):
         await __handle_message_prompt(socket=socket, prompt=request)
     elif isinstance(request, OptionsSelectPromptRequest):
@@ -190,7 +189,7 @@ async def __handle_stream_verification_prompt(socket: WebSocketClientProtocol, p
         await _cleanup_video_handler()
 
 
-async def __handle_image_verification_prompt(
+async def _handle_image_verification_prompt(
     socket: WebSocketClientProtocol, prompt: ImageVerificationPromptRequest
 ) -> None:
     """Handle image verification prompts via HTTP server."""
@@ -244,7 +243,7 @@ async def __handle_image_verification_prompt(
         click.echo(colorize_error(f"❌ Error handling image verification: {e}"), err=True)
 
 
-async def __handle_push_av_stream_prompt(
+async def _handle_push_av_stream_prompt(
     socket: WebSocketClientProtocol, prompt: PushAVStreamVerificationRequest
 ) -> None:
     """Handle Push AV Stream verification prompts.
@@ -262,9 +261,6 @@ async def __handle_push_av_stream_prompt(
         # Default to https://localhost:1234
         local_ip = _get_local_ip()
         push_av_server_url = f"https://{local_ip}:1234"
-
-        # Import the HTTP server for simple prompt display
-        from .camera.camera_http_server import CameraHTTPServer
 
         http_server = CameraHTTPServer()
         response_queue = queue.Queue()

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -16,8 +16,10 @@
 import asyncio
 import json
 import os
+import queue
 import re
 import socket
+import time
 from typing import Any, Union
 
 import aioconsole
@@ -32,10 +34,12 @@ from th_cli.config import config
 from th_cli.shared_constants import MessageKeysEnum, MessageTypeEnum
 
 from .socket_schemas import (
+    ImageVerificationPromptRequest,
     MessagePromptRequest,
     OptionsSelectPromptRequest,
     PromptRequest,
     PromptResponse,
+    PushAVStreamVerificationRequest,
     StreamVerificationPromptRequest,
     TextInputPromptRequest,
     UserResponseStatusEnum,
@@ -68,10 +72,18 @@ async def handle_prompt(socket: WebSocketClientProtocol, request: PromptRequest,
     """Handle all types of prompts with correct inheritance order."""
     click.echo("=======================================")
 
-    if message_type == MessageTypeEnum.STREAM_VERIFICATION_REQUEST or isinstance(
+    if message_type == MessageTypeEnum.IMAGE_VERIFICATION_REQUEST or isinstance(
+        request, ImageVerificationPromptRequest
+    ):
+        await __handle_image_verification_prompt(socket=socket, prompt=request)
+    elif message_type == MessageTypeEnum.STREAM_VERIFICATION_REQUEST or isinstance(
         request, StreamVerificationPromptRequest
     ):
         await __handle_stream_verification_prompt(socket=socket, prompt=request)
+    elif message_type == MessageTypeEnum.PUSH_AV_STREAM_VERIFICATION_REQUEST or isinstance(
+        request, PushAVStreamVerificationRequest
+    ):
+        await __handle_push_av_stream_prompt(socket=socket, prompt=request)
     elif message_type == MessageTypeEnum.MESSAGE_REQUEST or isinstance(request, MessagePromptRequest):
         await __handle_message_prompt(socket=socket, prompt=request)
     elif isinstance(request, OptionsSelectPromptRequest):
@@ -176,6 +188,143 @@ async def __handle_stream_verification_prompt(socket: WebSocketClientProtocol, p
         click.echo(colorize_error(f"Error handling video prompt: {e}"), err=True)
         # Clean up using the shared instance
         await _cleanup_video_handler()
+
+
+async def __handle_image_verification_prompt(socket: WebSocketClientProtocol, prompt: ImageVerificationPromptRequest) -> None:
+    """Handle image verification prompts via HTTP server."""
+    try:
+        # Convert hex string back to bytes (format: "ff,d8,ff,e0" → bytes)
+        image_hex_clean = prompt.image_hex_str.replace(', ', '').replace(',', '')
+        image_data = bytes.fromhex(image_hex_clean)
+
+        # Use existing ImageVerificationHandler
+        from .camera.image_handler import ImageVerificationHandler
+
+        image_handler = ImageVerificationHandler()
+        image_handler.set_prompt_data(prompt.prompt, prompt.options, image_data)
+
+        # Start HTTP server
+        await image_handler.start_image_server(str(prompt.message_id))
+
+        # Show user instructions
+        local_ip = _get_local_ip()
+        click.echo(f"📸 Image verification required!")
+        click.echo(f"🌐 Open: http://{local_ip}:{image_handler.http_server.port}/")
+        click.echo(f"📝 {prompt.prompt}")
+        click.echo(f"⏰ Timeout: {prompt.timeout}s")
+
+        # Wait for user response
+        user_answer = await image_handler.wait_for_user_response(float(prompt.timeout))
+
+        # Clean up
+        image_handler.stop_image_server()
+
+        if user_answer is None:
+            click.echo(colorize_error("❌ No response received - timed out"), err=True)
+            return
+
+        # Display the user's selected response
+        selected_option = None
+        for option_text, option_id in prompt.options.items():
+            if option_id == user_answer:
+                selected_option = option_text
+                break
+
+        if selected_option:
+            click.echo(f"✅ User selected: {colorize_key_value(str(user_answer), selected_option)}")
+        else:
+            click.echo(f"✅ User response: {user_answer}")
+
+        # Send response back to test
+        await _send_prompt_response(socket=socket, response=user_answer, prompt=prompt)
+
+    except Exception as e:
+        click.echo(colorize_error(f"❌ Error handling image verification: {e}"), err=True)
+
+
+async def __handle_push_av_stream_prompt(socket: WebSocketClientProtocol, prompt: PushAVStreamVerificationRequest) -> None:
+    """Handle Push AV Stream verification prompts.
+
+    This displays information about verifying video uploaded to the external Push AV Server,
+    and provides a simple web UI for the user to respond with PASS/FAIL.
+    """
+    try:
+        # Validate prompt has required attributes
+        if not hasattr(prompt, "options") or not prompt.options:
+            click.echo(colorize_error("Push AV Stream prompt missing required options"), err=True)
+            return
+
+        # Try to determine Push AV Server URL
+        # Default to https://localhost:1234
+        local_ip = _get_local_ip()
+        push_av_server_url = f"https://{local_ip}:1234"
+
+        # Import the HTTP server for simple prompt display
+        from .camera.camera_http_server import CameraHTTPServer
+
+        http_server = CameraHTTPServer()
+        response_queue = queue.Queue()
+
+        # Start HTTP server with Push AV Stream verification page
+        # Pass None for video_handler since we're not streaming video
+        http_server.start(
+            mp4_queue=None,  # No video streaming needed
+            response_queue=response_queue,
+            video_handler=None,  # No video handler needed
+            prompt_options=prompt.options,
+            prompt_text=prompt.prompt,
+            is_push_av_verification=True,  # Use Push AV template
+            push_av_server_url=push_av_server_url,  # Pass Push AV Server URL
+        )
+
+        # Display instructions
+        click.echo(italic(prompt.prompt))
+        click.echo(f"📡 Push AV Stream Verification")
+        click.echo(f"🌐 Please verify at: http://{local_ip}:{http_server.port}/")
+        click.echo(f"   Push AV Server: {push_av_server_url}")
+        click.echo(f"   The web interface will show available streams and allow playback.")
+        click.echo("")
+        click.echo("Waiting for your response in the web interface...")
+
+        # Wait for user response from web UI
+        user_answer = None
+        start_time = time.time()
+        timeout = float(prompt.timeout)
+
+        click.echo(f"Debug: Starting to wait for response (timeout: {timeout}s)...")
+        while time.time() - start_time < timeout:
+            try:
+                user_answer = response_queue.get_nowait()
+                click.echo(f"Debug: Received response from queue: {user_answer}")
+                break
+            except queue.Empty:
+                await asyncio.sleep(0.1)
+                continue
+
+        # Stop HTTP server
+        click.echo("Debug: Stopping HTTP server...")
+        http_server.stop()
+
+        if user_answer is None:
+            click.echo(colorize_error("No response received from web interface"), err=True)
+            return
+
+        # Display the user's selected response
+        selected_option = None
+        for option_text, option_id in prompt.options.items():
+            if option_id == user_answer:
+                selected_option = option_text
+                break
+
+        if selected_option:
+            click.echo(f"✅ User selected: {colorize_key_value(str(user_answer), selected_option)}")
+        else:
+            click.echo(f"✅ User response: {user_answer}")
+
+        await _send_prompt_response(socket=socket, response=user_answer, prompt=prompt)
+
+    except Exception as e:
+        click.echo(colorize_error(f"Error handling Push AV Stream prompt: {e}"), err=True)
 
 
 async def handle_file_upload_request(socket: WebSocketClientProtocol, request: PromptRequest) -> None:

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -210,7 +210,7 @@ async def __handle_image_verification_prompt(
 
         # Show user instructions
         local_ip = _get_local_ip()
-        click.echo(f"📸 Image verification required!")
+        click.echo("📸 Image verification required!")
         click.echo(f"🌐 Open: http://{local_ip}:{image_handler.http_server.port}")
         click.echo(f"📝 {prompt.prompt}")
         click.echo(f"⏰ Timeout: {prompt.timeout}s")
@@ -285,9 +285,9 @@ async def __handle_push_av_stream_prompt(
         # Display instructions
         verification_url = f"http://{local_ip}:{http_server.port}"
         click.echo(italic(prompt.prompt))
-        click.echo(f"📡 Push AV Stream Verification")
+        click.echo("📡 Push AV Stream Verification")
         click.echo(f"🌐 Please verify at: {verification_url}")
-        click.echo(f"   The web interface will show available streams and allow playback.")
+        click.echo("   The web interface will show available streams and allow playback.")
         click.echo("")
         click.echo("Waiting for your response in the web interface...")
 

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -152,7 +152,7 @@ async def __handle_stream_verification_prompt(socket: WebSocketClientProtocol, p
 
         click.echo(italic(prompt.prompt))
         local_ip = _get_local_ip()
-        click.echo(f"🎬 Please verify the video at: http://{local_ip}:{video_handler.http_server.port}/")
+        click.echo(f"🎬 Please verify the video at: http://{local_ip}:{video_handler.http_server.port}")
 
         click.echo("Waiting for your response in the web interface...")
 
@@ -190,11 +190,13 @@ async def __handle_stream_verification_prompt(socket: WebSocketClientProtocol, p
         await _cleanup_video_handler()
 
 
-async def __handle_image_verification_prompt(socket: WebSocketClientProtocol, prompt: ImageVerificationPromptRequest) -> None:
+async def __handle_image_verification_prompt(
+    socket: WebSocketClientProtocol, prompt: ImageVerificationPromptRequest
+) -> None:
     """Handle image verification prompts via HTTP server."""
     try:
         # Convert hex string back to bytes (format: "ff,d8,ff,e0" → bytes)
-        image_hex_clean = prompt.image_hex_str.replace(', ', '').replace(',', '')
+        image_hex_clean = prompt.image_hex_str.replace(", ", "").replace(",", "")
         image_data = bytes.fromhex(image_hex_clean)
 
         # Use existing ImageVerificationHandler
@@ -209,7 +211,7 @@ async def __handle_image_verification_prompt(socket: WebSocketClientProtocol, pr
         # Show user instructions
         local_ip = _get_local_ip()
         click.echo(f"📸 Image verification required!")
-        click.echo(f"🌐 Open: http://{local_ip}:{image_handler.http_server.port}/")
+        click.echo(f"🌐 Open: http://{local_ip}:{image_handler.http_server.port}")
         click.echo(f"📝 {prompt.prompt}")
         click.echo(f"⏰ Timeout: {prompt.timeout}s")
 
@@ -242,7 +244,9 @@ async def __handle_image_verification_prompt(socket: WebSocketClientProtocol, pr
         click.echo(colorize_error(f"❌ Error handling image verification: {e}"), err=True)
 
 
-async def __handle_push_av_stream_prompt(socket: WebSocketClientProtocol, prompt: PushAVStreamVerificationRequest) -> None:
+async def __handle_push_av_stream_prompt(
+    socket: WebSocketClientProtocol, prompt: PushAVStreamVerificationRequest
+) -> None:
     """Handle Push AV Stream verification prompts.
 
     This displays information about verifying video uploaded to the external Push AV Server,
@@ -275,13 +279,14 @@ async def __handle_push_av_stream_prompt(socket: WebSocketClientProtocol, prompt
             prompt_text=prompt.prompt,
             is_push_av_verification=True,  # Use Push AV template
             push_av_server_url=push_av_server_url,  # Pass Push AV Server URL
+            local_ip=local_ip,  # Pass local IP for proxy URL construction
         )
 
         # Display instructions
+        verification_url = f"http://{local_ip}:{http_server.port}"
         click.echo(italic(prompt.prompt))
         click.echo(f"📡 Push AV Stream Verification")
-        click.echo(f"🌐 Please verify at: http://{local_ip}:{http_server.port}/")
-        click.echo(f"   Push AV Server: {push_av_server_url}")
+        click.echo(f"🌐 Please verify at: {verification_url}")
         click.echo(f"   The web interface will show available streams and allow playback.")
         click.echo("")
         click.echo("Waiting for your response in the web interface...")
@@ -291,18 +296,15 @@ async def __handle_push_av_stream_prompt(socket: WebSocketClientProtocol, prompt
         start_time = time.time()
         timeout = float(prompt.timeout)
 
-        click.echo(f"Debug: Starting to wait for response (timeout: {timeout}s)...")
         while time.time() - start_time < timeout:
             try:
                 user_answer = response_queue.get_nowait()
-                click.echo(f"Debug: Received response from queue: {user_answer}")
                 break
             except queue.Empty:
                 await asyncio.sleep(0.1)
                 continue
 
         # Stop HTTP server
-        click.echo("Debug: Stopping HTTP server...")
         http_server.stop()
 
         if user_answer is None:


### PR DESCRIPTION
### What changed
This PR implements CLI support for Push AV (Push Audio/Video) Stream Transport tests  via the CLI.


#### How It Works

  The CLI presents Push AV verification prompts using the same interface as the Test Harness browser UI:
  1. When a Push AV test runs, the CLI starts a local HTTP server
  2. The CLI displays a URL to the user (e.g., `http://192.168.1.50:8999`)
  3. User opens the URL in their browser to see the DASH player interface
  4. The browser displays the same verification UI as TH web interface
  5. User verifies the video stream and clicks PASS/FAIL
  6. The CLI forwards the response to complete the test

When executing in TH UI this is how the Push AV prompt is displayed:
<img width="641" height="883" alt="Screenshot 2026-01-12 at 19 08 53" src="https://github.com/user-attachments/assets/73d4f879-5301-49a4-a67b-ca951b0e3fc6" />

Now, the CLI will display a similar prompt like bellow:
<img width="740" height="949" alt="Screenshot 2026-01-13 at 19 38 43" src="https://github.com/user-attachments/assets/572cae20-12a0-40fa-882e-7216e6a2421d" />

The cli execution log shows Push AV tests like bellow:
<img width="1147" height="698" alt="Screenshot 2026-01-13 at 19 40 32" src="https://github.com/user-attachments/assets/87f64884-b9e0-4baf-97a7-24564d7f3e53" />


### Related Issue
https://github.com/project-chip/certification-tool/issues/783

### Testing
Unit test added and Passing
<img width="1194" height="294" alt="Screenshot 2026-01-13 at 19 13 38" src="https://github.com/user-attachments/assets/ca70c0e1-fc9f-4d5c-95f2-f8c95d8b6b1a" />

Run a Push AV test successfully by running this command in CLI: `th-cli run-tests -t TC_PAVSTI_1_2 --project-id 2`