### PR TITLE
[Feature] Double-Dash Extra Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ th-cli run-tests -t TC-ACE-1.1 -- --timeout 60 --int-arg some-arg:1 --bool-arg f
 th-cli run-tests -t TC-ACE-1.1 --config my-config.json --no-color -- --trace-to json:log
 ```
 
-Common SDK test arguments you might want to use:
+Common SDK test arguments you might want to use for example:
 - `--endpoint <value>` - Choose the device endpoint
 - `--trace-to json:log` - Enable detailed trace logging
 - `--timeout <seconds>` - Override default test timeout
@@ -135,7 +135,7 @@ Common SDK test arguments you might want to use:
 - `--string-arg <name>:<value>` - Pass string argument to test
 - `--hex-arg <name>:<hex-value>` - Pass hex value argument to test
 
-**Note:** These extra arguments are applied to ALL Python tests in the test run. Invalid arguments will cause test failures, so ensure the arguments are valid for the SDK test framework.
+**Note:** These extra arguments are applied to ALL Test Cases in the test run. Invalid arguments could cause test failures, so ensure the arguments are valid for the SDK test framework.
 
 ### test-run-execution-history
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run `th-cli available-tests` to get a list of tests available in Test Harness, p
 
 ### run-tests
 
-Run `th-cli run-tests --tests-list <tests> [--title, -n <title>] [--config, -c <config>] [--pics-config-folder, -p <pics-config-folder>] [--project-id <ID>] [--no-color]` to start a new test execution.
+Run `th-cli run-tests --tests-list <tests> [--title, -n <title>] [--config, -c <config>] [--pics-config-folder, -p <pics-config-folder>] [--project-id <ID>] [--no-color] [-- <extra-sdk-args>]` to start a new test execution.
 
 Required:
 - `--tests-list`: Comma-separated list of test case identifiers (e.g. --tests-list TC-ACE-1.1,TC_ACE_1_3)
@@ -74,6 +74,7 @@ Optional:
 - `--pics-config-folder`: Path to the folder that contains PICS files. If not specified, no PICS file will be used.
 - `--project-id`: Project ID that this test run belongs to. If not provided, uses the default 'CLI Execution Project' in TH.
 - `--no-color`: Disable all colors from the CLI's output text of this test run execution
+- `-- <extra-sdk-args>`: Pass additional arguments directly to the SDK container Python tests. Use the double dash (`--`) separator followed by any SDK test arguments. These arguments will be added to every Python test execution in the run.
 
 **Example config files:**
 
@@ -105,6 +106,36 @@ Full project format (works with all commands):
   }
 }
 ```
+
+**Passing Extra Arguments to SDK Tests:**
+
+You can pass additional arguments directly to the SDK container test execution using the `--` separator. Everything after `--` will be passed as-is to the Python test runner.
+
+Examples:
+```bash
+# Enable trace logging for all tests in the run
+th-cli run-tests -t TC-ACE-1.1 -- --trace-to json:log
+
+# Pass boolean argument
+th-cli run-tests -t TC-ACE-1.1,TC-ACE-1.2 -- --bool-arg flag:true
+
+# Pass multiple extra arguments
+th-cli run-tests -t TC-ACE-1.1 -- --timeout 60 --int-arg some-arg:1 --bool-arg flag:true
+
+# Combine with other CLI options
+th-cli run-tests -t TC-ACE-1.1 --config my-config.json --no-color -- --trace-to json:log
+```
+
+Common SDK test arguments you might want to use:
+- `--endpoint <value>` - Choose the device endpoint
+- `--trace-to json:log` - Enable detailed trace logging
+- `--timeout <seconds>` - Override default test timeout
+- `--int-arg <name>:<value>` - Pass integer argument to test
+- `--bool-arg <name>:<true|false>` - Pass boolean argument to test
+- `--string-arg <name>:<value>` - Pass string argument to test
+- `--hex-arg <name>:<hex-value>` - Pass hex value argument to test
+
+**Note:** These extra arguments are applied to ALL Python tests in the test run. Invalid arguments will cause test failures, so ensure the arguments are valid for the SDK test framework.
 
 ### test-run-execution-history
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,26 @@ def mock_pics_dir(temp_dir: Path) -> Path:
     (pics_dir / "test_cluster.xml").write_text(pics_xml_content)
     return pics_dir
 
+@pytest.fixture
+def sample_default_config_dict() -> dict:
+    """Create a sample default configuration dictionary."""
+    return {
+        "network": {
+            "wifi": {
+                "ssid": "default_wifi",
+                "password": "default_password"
+            },
+            "thread": {
+                "operational_dataset_hex": "default_hex"
+            }
+        },
+        "dut_config": {
+            "pairing_mode": "ble-wifi",
+            "setup_code": "20202021",
+            "discriminator": "3840",
+            "trace_log": False
+        }
+    }
 
 @pytest.fixture
 def mock_api_client() -> Mock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,7 @@ def mock_pics_dir(temp_dir: Path) -> Path:
     (pics_dir / "test_cluster.xml").write_text(pics_xml_content)
     return pics_dir
 
+
 @pytest.fixture
 def sample_default_config_dict() -> dict:
     """Create a sample default configuration dictionary."""
@@ -162,6 +163,7 @@ def sample_default_config_dict() -> dict:
             "trace_log": False
         }
     }
+
 
 @pytest.fixture
 def mock_api_client() -> Mock:

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -881,10 +881,10 @@ class TestRunTestsWithExtraArgs:
         id_start.return_value = sample_test_run_execution
 
         with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
-            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
-            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
-            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
-            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+             patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+             patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+             patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+             patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
             mock_socket = Mock()
             mock_socket.connect_websocket = AsyncMock()
             mock_socket_class.return_value = mock_socket
@@ -923,10 +923,10 @@ class TestRunTestsWithExtraArgs:
         id_start.return_value = sample_test_run_execution
 
         with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
-            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
-            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
-            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
-            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+             patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+             patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+             patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+             patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
             mock_socket = Mock()
             mock_socket.connect_websocket = AsyncMock()
             mock_socket_class.return_value = mock_socket
@@ -969,10 +969,10 @@ class TestRunTestsWithExtraArgs:
         id_start.return_value = sample_test_run_execution
 
         with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
-            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
-            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
-            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
-            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+             patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+             patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+             patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+             patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
             mock_socket = Mock()
             mock_socket.connect_websocket = AsyncMock()
             mock_socket_class.return_value = mock_socket
@@ -1011,10 +1011,10 @@ class TestRunTestsWithExtraArgs:
         id_start.return_value = sample_test_run_execution
 
         with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
-            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
-            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
-            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
-            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+             patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+             patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+             patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+             patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
             mock_socket = Mock()
             mock_socket.connect_websocket = AsyncMock()
             mock_socket_class.return_value = mock_socket
@@ -1054,15 +1054,15 @@ class TestRunTestsWithExtraArgs:
         id_start.return_value = sample_test_run_execution
 
         with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
-            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
-            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
-            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
-            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict), \
-            patch("th_cli.commands.run_tests.copy.deepcopy") as mock_deepcopy:
-            
+             patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+             patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+             patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+             patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict), \
+             patch("th_cli.commands.run_tests.copy.deepcopy") as mock_deepcopy:
+
             # Configure deepcopy to return a new dict
             mock_deepcopy.return_value = dict(sample_default_config_dict)
-            
+
             mock_socket = Mock()
             mock_socket.connect_websocket = AsyncMock()
             mock_socket_class.return_value = mock_socket

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Project CHIP Authors
+# Copyright (c) 2025-2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ from httpx import Headers
 
 from th_cli.api_lib_autogen import models as api_models
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
-from th_cli.commands.run_tests import run_tests
+from th_cli.commands.run_tests import run_tests, _parse_extra_args
 from th_cli.exceptions import ConfigurationError
 
 
@@ -32,27 +32,6 @@ from th_cli.exceptions import ConfigurationError
 @pytest.mark.cli
 class TestRunTestsCommand:
     """Test cases for the run_tests command."""
-
-    @pytest.fixture
-    def sample_default_config_dict(self) -> dict:
-        """Create a sample default configuration dictionary."""
-        return {
-            "network": {
-                "wifi": {
-                    "ssid": "default_wifi",
-                    "password": "default_password"
-                },
-                "thread": {
-                    "operational_dataset_hex": "default_hex"
-                }
-            },
-            "dut_config": {
-                "pairing_mode": "ble-wifi",
-                "setup_code": "20202021",
-                "discriminator": "3840",
-                "trace_log": False
-            }
-        }
 
     def test_run_tests_success_minimal_args(
         self,
@@ -762,3 +741,339 @@ class TestRunTestsCommand:
         assert result.exit_code == 1
         assert "API creation failed" in result.output
         mock_api_client.aclose.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestParseExtraArgs:
+    """Test cases for the _parse_extra_args function."""
+
+    def test_parse_extra_args_single_argument(self) -> None:
+        """Test parsing a single extra argument."""
+        # Arrange
+        args = ["--int-arg", "endpoint:2"]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {"int-arg": "endpoint:2"}
+
+    def test_parse_extra_args_multiple_arguments(self) -> None:
+        """Test parsing multiple extra arguments."""
+        # Arrange
+        args = ["--int-arg", "endpoint:2", "--bool-arg", "flag:true"]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {"int-arg": "endpoint:2", "bool-arg": "flag:true"}
+
+    def test_parse_extra_args_with_short_flags(self) -> None:
+        """Test parsing extra arguments with short flags."""
+        # Arrange
+        args = ["-a", "value1", "-b", "value2"]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {"a": "value1", "b": "value2"}
+
+    def test_parse_extra_args_mixed_long_and_short(self) -> None:
+        """Test parsing mixed long and short flags."""
+        # Arrange
+        args = ["--long-arg", "value1", "-s", "value2"]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {"long-arg": "value1", "s": "value2"}
+
+    def test_parse_extra_args_flag_without_value(self) -> None:
+        """Test parsing flag without value (sets to empty string)."""
+        # Arrange
+        args = ["--bool-flag", "--another-arg", "value"]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {"bool-flag": "", "another-arg": "value"}
+
+    def test_parse_extra_args_empty_list(self) -> None:
+        """Test parsing empty args list."""
+        # Arrange
+        args = []
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {}
+
+    def test_parse_extra_args_complex_values(self) -> None:
+        """Test parsing arguments with complex values."""
+        # Arrange
+        args = [
+            "--string-arg", "PICS_SC_2_2:false",
+            "--json-arg", '{"key":"value"}',
+            "--numeric-arg", "nodeId:305414945",
+        ]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {
+            "string-arg": "PICS_SC_2_2:false",
+            "json-arg": '{"key":"value"}',
+            "numeric-arg": "nodeId:305414945",
+        }
+
+    def test_parse_extra_args_colons_in_values(self) -> None:
+        """Test parsing SDK test parameter format with colons."""
+        # Arrange
+        args = [
+            "--int-arg", "endpoint:2",
+            "--string-arg", "discriminator:1234",
+            "--bool-arg", "someBoolFlag:true",
+        ]
+
+        # Act
+        result = _parse_extra_args(args)
+
+        # Assert
+        assert result == {
+            "int-arg": "endpoint:2",
+            "string-arg": "discriminator:1234",
+            "bool-arg": "someBoolFlag:true",
+        }
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestRunTestsWithExtraArgs:
+    """Test cases for run_tests command with extra arguments feature."""
+
+    def test_run_tests_with_extra_args_basic(
+        self,
+        cli_runner: CliRunner,
+        mock_async_apis: Mock,
+        mock_api_client: Mock,
+        sample_test_collections: api_models.TestCollections,
+        sample_test_run_execution: api_models.TestRunExecutionWithChildren,
+        sample_default_config_dict: dict,
+    ) -> None:
+        """Test run tests with basic extra arguments."""
+        # Arrange
+        project_api = mock_async_apis.projects_api.default_config_api_v1_projects_default_config_get
+        test_collection_api = mock_async_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        test_run_executions_api = mock_async_apis.test_run_executions_api
+        cli_api = test_run_executions_api.create_test_run_execution_cli_api_v1_test_run_executions_cli_post
+        id_start = test_run_executions_api.start_test_run_execution_api_v1_test_run_executions_id_start_post
+
+        project_api.return_value = sample_default_config_dict
+        test_collection_api.return_value = sample_test_collections
+        cli_api.return_value = sample_test_run_execution
+        id_start.return_value = sample_test_run_execution
+
+        with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
+            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+            mock_socket = Mock()
+            mock_socket.connect_websocket = AsyncMock()
+            mock_socket_class.return_value = mock_socket
+
+            # Act
+            result = cli_runner.invoke(run_tests, [
+                "--tests-list", "TC-ACE-1.1",
+                "--", "--int-arg", "endpoint:2"
+            ])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "Extra SDK Test Parameters" in result.output
+        assert "endpoint:2" in result.output
+
+    def test_run_tests_with_multiple_extra_args(
+        self,
+        cli_runner: CliRunner,
+        mock_async_apis: Mock,
+        mock_api_client: Mock,
+        sample_test_collections: api_models.TestCollections,
+        sample_test_run_execution: api_models.TestRunExecutionWithChildren,
+        sample_default_config_dict: dict,
+    ) -> None:
+        """Test run tests with multiple extra arguments."""
+        # Arrange
+        project_api = mock_async_apis.projects_api.default_config_api_v1_projects_default_config_get
+        test_collection_api = mock_async_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        test_run_executions_api = mock_async_apis.test_run_executions_api
+        cli_api = test_run_executions_api.create_test_run_execution_cli_api_v1_test_run_executions_cli_post
+        id_start = test_run_executions_api.start_test_run_execution_api_v1_test_run_executions_id_start_post
+
+        project_api.return_value = sample_default_config_dict
+        test_collection_api.return_value = sample_test_collections
+        cli_api.return_value = sample_test_run_execution
+        id_start.return_value = sample_test_run_execution
+
+        with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
+            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+            mock_socket = Mock()
+            mock_socket.connect_websocket = AsyncMock()
+            mock_socket_class.return_value = mock_socket
+
+            # Act
+            result = cli_runner.invoke(run_tests, [
+                "--tests-list", "TC-ACE-1.1",
+                "--",
+                "--int-arg", "endpoint:2",
+                "--bool-arg", "flag:true",
+                "--string-arg", "discriminator:1234"
+            ])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "endpoint:2" in result.output
+        assert "flag:true" in result.output
+        assert "discriminator:1234" in result.output
+
+    def test_run_tests_without_extra_args(
+        self,
+        cli_runner: CliRunner,
+        mock_async_apis: Mock,
+        mock_api_client: Mock,
+        sample_test_collections: api_models.TestCollections,
+        sample_test_run_execution: api_models.TestRunExecutionWithChildren,
+        sample_default_config_dict: dict,
+    ) -> None:
+        """Test run tests without extra arguments (normal behavior)."""
+        # Arrange
+        project_api = mock_async_apis.projects_api.default_config_api_v1_projects_default_config_get
+        test_collection_api = mock_async_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        test_run_executions_api = mock_async_apis.test_run_executions_api
+        cli_api = test_run_executions_api.create_test_run_execution_cli_api_v1_test_run_executions_cli_post
+        id_start = test_run_executions_api.start_test_run_execution_api_v1_test_run_executions_id_start_post
+
+        project_api.return_value = sample_default_config_dict
+        test_collection_api.return_value = sample_test_collections
+        cli_api.return_value = sample_test_run_execution
+        id_start.return_value = sample_test_run_execution
+
+        with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
+            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+            mock_socket = Mock()
+            mock_socket.connect_websocket = AsyncMock()
+            mock_socket_class.return_value = mock_socket
+
+            # Act
+            result = cli_runner.invoke(run_tests, [
+                "--tests-list", "TC-ACE-1.1"
+            ])
+
+        # Assert
+        assert result.exit_code == 0
+        # Should not show extra args message when no extra args provided
+        assert "Extra SDK Test Parameters" not in result.output
+
+    def test_run_tests_extra_args_with_config_file(
+        self,
+        cli_runner: CliRunner,
+        mock_async_apis: Mock,
+        mock_api_client: Mock,
+        sample_test_collections: api_models.TestCollections,
+        sample_test_run_execution: api_models.TestRunExecutionWithChildren,
+        sample_default_config_dict: dict,
+        mock_json_config_file,
+    ) -> None:
+        """Test run tests with both config file and extra arguments."""
+        # Arrange
+        project_api = mock_async_apis.projects_api.default_config_api_v1_projects_default_config_get
+        test_collection_api = mock_async_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        test_run_executions_api = mock_async_apis.test_run_executions_api
+        cli_api = test_run_executions_api.create_test_run_execution_cli_api_v1_test_run_executions_cli_post
+        id_start = test_run_executions_api.start_test_run_execution_api_v1_test_run_executions_id_start_post
+
+        project_api.return_value = sample_default_config_dict
+        test_collection_api.return_value = sample_test_collections
+        cli_api.return_value = sample_test_run_execution
+        id_start.return_value = sample_test_run_execution
+
+        with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
+            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict):
+            mock_socket = Mock()
+            mock_socket.connect_websocket = AsyncMock()
+            mock_socket_class.return_value = mock_socket
+
+            # Act
+            result = cli_runner.invoke(run_tests, [
+                "--tests-list", "TC-ACE-1.1",
+                "--config", str(mock_json_config_file),
+                "--", "--int-arg", "endpoint:2"
+            ])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "CLI Test Run Execution Config" in result.output
+        assert "Extra SDK Test Parameters" in result.output
+
+    def test_run_tests_verify_deep_copy_isolation(
+        self,
+        cli_runner: CliRunner,
+        mock_async_apis: Mock,
+        mock_api_client: Mock,
+        sample_test_collections: api_models.TestCollections,
+        sample_test_run_execution: api_models.TestRunExecutionWithChildren,
+        sample_default_config_dict: dict,
+    ) -> None:
+        """Test that test_run_config uses deepcopy for isolation."""
+        # Arrange
+        project_api = mock_async_apis.projects_api.default_config_api_v1_projects_default_config_get
+        test_collection_api = mock_async_apis.test_collections_api.read_test_collections_api_v1_test_collections_get
+        test_run_executions_api = mock_async_apis.test_run_executions_api
+        cli_api = test_run_executions_api.create_test_run_execution_cli_api_v1_test_run_executions_cli_post
+        id_start = test_run_executions_api.start_test_run_execution_api_v1_test_run_executions_id_start_post
+
+        project_api.return_value = sample_default_config_dict
+        test_collection_api.return_value = sample_test_collections
+        cli_api.return_value = sample_test_run_execution
+        id_start.return_value = sample_test_run_execution
+
+        with patch("th_cli.commands.run_tests.get_client", return_value=mock_api_client), \
+            patch("th_cli.commands.run_tests.AsyncApis", return_value=mock_async_apis), \
+            patch("th_cli.commands.run_tests.test_logging.configure_logger_for_run", return_value="./test.log"), \
+            patch("th_cli.commands.run_tests.TestRunSocket") as mock_socket_class, \
+            patch("th_cli.commands.run_tests.convert_nested_to_dict", return_value=sample_default_config_dict), \
+            patch("th_cli.commands.run_tests.copy.deepcopy") as mock_deepcopy:
+            
+            # Configure deepcopy to return a new dict
+            mock_deepcopy.return_value = dict(sample_default_config_dict)
+            
+            mock_socket = Mock()
+            mock_socket.connect_websocket = AsyncMock()
+            mock_socket_class.return_value = mock_socket
+
+            # Act
+            result = cli_runner.invoke(run_tests, [
+                "--tests-list", "TC-ACE-1.1",
+                "--", "--int-arg", "endpoint:2"
+            ])
+
+        # Assert
+        assert result.exit_code == 0
+        # Verify deepcopy was called to ensure isolation
+        mock_deepcopy.assert_called_once()

--- a/tests/test_test_run_execution.py
+++ b/tests/test_test_run_execution.py
@@ -1096,4 +1096,3 @@ Escape sequences: \n\t\r"""
         assert result.exit_code != 0
         assert "--project-id" in result.output
         assert "not applicable" in result.output or "Error" in result.output
-

--- a/th_cli/api_lib_autogen/models.py
+++ b/th_cli/api_lib_autogen/models.py
@@ -29,6 +29,7 @@ class BodyCreateTestRunExecutionApiV1TestRunExecutionsPost(BaseModel):
 
 class BodyCreateTestRunExecutionCliApiV1TestRunExecutionsCliPost(BodyCreateTestRunExecutionApiV1TestRunExecutionsPost):
     config: "Dict[str, Any]" = Field(default_factory=dict, alias="config")
+    execution_config: "dict[str, Any] | None" = Field(None, alias="execution_config")
     pics: "Optional[Dict[str, Any]]" = Field(None, alias="pics")
 
 
@@ -194,13 +195,15 @@ class TestRunExecutionStats(BaseModel):
 
 class TestRunExecutionWithChildren(BaseModel):
     title: "str" = Field(..., alias="title")
+    description: "str | None" = Field(None, alias="description")
+    execution_config: "dict[str, Any] | None" = Field(None, alias="execution_config")
     test_run_config_id: "Optional[int]" = Field(None, alias="test_run_config_id")
     project_id: "Optional[int]" = Field(None, alias="project_id")
-    description: "Optional[str]" = Field(None, alias="description")
     id: "int" = Field(..., alias="id")
     state: "TestStateEnum" = Field(..., alias="state")
     started_at: "Optional[datetime]" = Field(None, alias="started_at")
     completed_at: "Optional[datetime]" = Field(None, alias="completed_at")
+    imported_at: "datetime | None" = Field(None, alias="imported_at")
     archived_at: "Optional[datetime]" = Field(None, alias="archived_at")
     operator: "Optional[Operator]" = Field(None, alias="operator")
     test_suite_executions: "Optional[List[TestSuiteExecution]]" = Field(None, alias="test_suite_executions")

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -121,7 +121,6 @@ async def run_tests(
     Raises:
         CLIError: If there are validation or execution errors
     """
-    
     # Extract and parse extra arguments from context (args after --)
     extra_test_params = _parse_extra_args(list(ctx.args)) if ctx.args else {}
 
@@ -166,7 +165,10 @@ async def run_tests(
         
         # Merge extra test parameters if provided (temporary for this execution only)
         if extra_test_params:
-            click.echo(colorize_key_value("Extra SDK Test Parameters (This Run Only)", json.dumps(extra_test_params, indent=JSON_INDENT)))
+            click.echo(colorize_key_value(
+                "Extra SDK Test Parameters (This Run Only)",
+                json.dumps(extra_test_params, indent=JSON_INDENT)
+            ))
             if "test_parameters" not in test_run_config:
                 test_run_config["test_parameters"] = {}
             test_run_config["test_parameters"].update(extra_test_params)
@@ -246,36 +248,37 @@ def _parse_extra_args(args: list[str]) -> dict[str, str]:
     Returns:
         Dictionary of parameter name to value mappings
     """
-    params = {}
+    params: dict[str, str] = {}
     i = 0
+
     while i < len(args):
         arg = args[i]
-        # Remove leading dashes
-        if arg.startswith('--'):
-            param_name = arg[2:]  # Remove '--'
-            # Check if next arg exists and doesn't start with --
-            if i + 1 < len(args) and not args[i + 1].startswith('--'):
-                param_value = args[i + 1]
-                params[param_name] = param_value
-                i += 2  # Skip both parameter and value
-            else:
-                # Flag parameter with no value, set to empty string or true
-                params[param_name] = ""
-                i += 1
-        elif arg.startswith('-') and not arg.startswith('--'):
-            # Single dash argument (short form)
-            param_name = arg[1:]  # Remove '-'
-            if i + 1 < len(args) and not args[i + 1].startswith('-'):
-                param_value = args[i + 1]
-                params[param_name] = param_value
-                i += 2
-            else:
-                params[param_name] = ""
-                i += 1
-        else:
-            # Value without parameter, skip
+
+        # Skip non-flag arguments
+        if not arg.startswith('-'):
             i += 1
-    
+            continue
+
+        # Extract parameter name (remove leading dashes)
+        if arg.startswith('--'):
+            param_name = arg[2:]
+        else:
+            param_name = arg[1:]
+
+        # Check if next argument exists and is a value (not a flag)
+        has_value = (
+            i + 1 < len(args)
+            and not args[i + 1].startswith('-')
+        )
+
+        if has_value:
+            params[param_name] = args[i + 1]
+            i += 2  # Skip both parameter and value
+        else:
+            # Flag without value (e.g., --verbose)
+            params[param_name] = ""
+            i += 1
+
     return params
 
 

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -166,7 +166,7 @@ async def run_tests(
         
         # Merge extra test parameters if provided (temporary for this execution only)
         if extra_test_params:
-            click.echo(colorize_key_value("Extra SDK Test Parameters (This Run Only, Final Version)", json.dumps(extra_test_params, indent=JSON_INDENT)))
+            click.echo(colorize_key_value("Extra SDK Test Parameters (This Run Only)", json.dumps(extra_test_params, indent=JSON_INDENT)))
             if "test_parameters" not in test_run_config:
                 test_run_config["test_parameters"] = {}
             test_run_config["test_parameters"].update(extra_test_params)

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Project CHIP Authors
+# Copyright (c) 2025-2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import asyncio
+import copy
 import datetime
 import json
 from typing import Any
@@ -53,6 +54,7 @@ JSON_INDENT = 2
     no_args_is_help=True,
     short_help=colorize_help("CLI execution of a test run"),
     help=colorize_cmd_help("run_tests", "CLI execution of a test run from selected tests"),
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
 )
 @click.option(
     "--tests-list",
@@ -95,7 +97,9 @@ JSON_INDENT = 2
     help=colorize_help("Disable colored output for test execution status."),
 )
 @async_cmd
+@click.pass_context
 async def run_tests(
+    ctx: click.Context,
     title: str,
     tests_list: str,
     config: str | None = None,
@@ -106,6 +110,7 @@ async def run_tests(
     """Execute a CLI test run from selected test cases.
 
     Args:
+        ctx: Click context containing extra arguments
         title: Name/title for the test run execution
         tests_list: Comma-separated list of test case identifiers
         config: Optional path to JSON configuration file
@@ -116,6 +121,9 @@ async def run_tests(
     Raises:
         CLIError: If there are validation or execution errors
     """
+    
+    # Extract and parse extra arguments from context (args after --)
+    extra_test_params = _parse_extra_args(list(ctx.args)) if ctx.args else {}
 
     # Set color preference if specified
     if no_color:
@@ -152,6 +160,17 @@ async def run_tests(
             project_config_dict = merge_configs(project_config_dict, config_data)
             click.echo(colorize_key_value("CLI Test Run Execution Config", project_config_dict))
 
+        # Create a DEEP copy for this test run execution to avoid modifying the original
+        # This ensures extra parameters only apply to THIS run, not future runs
+        test_run_config = copy.deepcopy(project_config_dict)
+        
+        # Merge extra test parameters if provided (temporary for this execution only)
+        if extra_test_params:
+            click.echo(colorize_key_value("Extra SDK Test Parameters (This Run Only, Final Version)", json.dumps(extra_test_params, indent=JSON_INDENT)))
+            if "test_parameters" not in test_run_config:
+                test_run_config["test_parameters"] = {}
+            test_run_config["test_parameters"].update(extra_test_params)
+
         # Read PICS configuration if provided
         pics = read_pics_config(pics_config_folder)
         click.echo(colorize_key_value("PICS Used", json.dumps(pics, indent=JSON_INDENT)))
@@ -167,10 +186,11 @@ async def run_tests(
             selected_tests=selected_tests_dict,
             title=title,
             config=project_config_dict,
+            execution_config=test_run_config,
             pics=pics,
             project_id=project_id,
         )
-        socket = TestRunSocket(new_test_run, project_config_dict)
+        socket = TestRunSocket(new_test_run, test_run_config)
         socket_task = asyncio.create_task(socket.connect_websocket())
         new_test_run = await _start_test_run(async_apis, new_test_run)
         socket.run = new_test_run
@@ -214,11 +234,57 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
     return await projects_api.default_config_api_v1_projects_default_config_get()
 
 
+def _parse_extra_args(args: list[str]) -> dict[str, str]:
+    """Parse extra arguments from -- separator into test_parameters format.
+    
+    Converts arguments as ['--int-arg', 'some-arg:2', '--bool-arg', 'flag:true']
+    into {'int-arg': 'some-arg:2', 'bool-arg': 'flag:true'}
+    
+    Args:
+        args: List of arguments after the -- separator
+        
+    Returns:
+        Dictionary of parameter name to value mappings
+    """
+    params = {}
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        # Remove leading dashes
+        if arg.startswith('--'):
+            param_name = arg[2:]  # Remove '--'
+            # Check if next arg exists and doesn't start with --
+            if i + 1 < len(args) and not args[i + 1].startswith('--'):
+                param_value = args[i + 1]
+                params[param_name] = param_value
+                i += 2  # Skip both parameter and value
+            else:
+                # Flag parameter with no value, set to empty string or true
+                params[param_name] = ""
+                i += 1
+        elif arg.startswith('-') and not arg.startswith('--'):
+            # Single dash argument (short form)
+            param_name = arg[1:]  # Remove '-'
+            if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                param_value = args[i + 1]
+                params[param_name] = param_value
+                i += 2
+            else:
+                params[param_name] = ""
+                i += 1
+        else:
+            # Value without parameter, skip
+            i += 1
+    
+    return params
+
+
 async def _create_new_test_run_cli(
     async_apis: AsyncApis,
     selected_tests: dict[str, Any],
     title: str,
     config: dict[str, Any] | None = None,
+    execution_config: dict[str, Any] | None = None,
     pics: dict[str, Any] | None = None,
     project_id: int | None = None,
 ) -> m.TestRunExecutionWithChildren:
@@ -228,7 +294,8 @@ async def _create_new_test_run_cli(
         async_apis: AsyncApis instance for making API calls
         selected_tests: Dictionary of selected test cases
         title: Title for the test run
-        config: Optional configuration dictionary
+        config: Optional configuration that updates project (persistent)
+        execution_config: Optional execution-specific configuration (temporary)
         pics: Optional PICS configuration dictionary
         project_id: Optional project ID
 
@@ -242,7 +309,11 @@ async def _create_new_test_run_cli(
 
     test_run_in = m.TestRunExecutionCreate(title=title, project_id=project_id)
     json_body = m.BodyCreateTestRunExecutionCliApiV1TestRunExecutionsCliPost(
-        test_run_execution_in=test_run_in, selected_tests=selected_tests, config=config, pics=pics
+        test_run_execution_in=test_run_in,
+        selected_tests=selected_tests,
+        config=config,
+        execution_config=execution_config,
+        pics=pics
     )
 
     try:

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -254,8 +254,8 @@ def _parse_extra_args(args: list[str]) -> dict[str, str]:
     while i < len(args):
         arg = args[i]
 
-        # Skip non-flag arguments
-        if not arg.startswith('-'):
+        # Skip non-flag arguments or subsequent --
+        if not arg.startswith('-') or arg == "--":
             i += 1
             continue
 

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -162,7 +162,7 @@ async def run_tests(
         # Create a DEEP copy for this test run execution to avoid modifying the original
         # This ensures extra parameters only apply to THIS run, not future runs
         test_run_config = copy.deepcopy(project_config_dict)
-        
+
         # Merge extra test parameters if provided (temporary for this execution only)
         if extra_test_params:
             click.echo(colorize_key_value(
@@ -238,13 +238,13 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
 
 def _parse_extra_args(args: list[str]) -> dict[str, str]:
     """Parse extra arguments from -- separator into test_parameters format.
-    
+
     Converts arguments as ['--int-arg', 'some-arg:2', '--bool-arg', 'flag:true']
     into {'int-arg': 'some-arg:2', 'bool-arg': 'flag:true'}
-    
+
     Args:
         args: List of arguments after the -- separator
-        
+
     Returns:
         Dictionary of parameter name to value mappings
     """


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/825
Depends on: https://github.com/project-chip/certification-tool-backend/pull/289
---

## Description

This PR implements the double dash (`--`) separator syntax in the `th-cli run-tests` command, enabling users to pass temporary test parameters that apply only to the current test execution without persisting to project configuration.

## 💡 Solution

Implemented standard CLI convention of using `--` separator to pass extra arguments that:
- Apply only to the current test execution
- Don't persist to project configuration
- Support SDK test parameter formats (`endpoint: 2`, `int-arg: some-arg:1234`, etc.)
- Work independently or combined with config files

### Usage Examples

```bash
# Extra args only (temporary)
th-cli run-tests -t TC-ACE-1.1 -- --endpoint 2

# Config file + extra args (file persists, extra args don't)
th-cli run-tests -t TC-ACE-1.1 --config base.json -- --int-arg some-arg:3

# Multiple extra args
th-cli run-tests -t TC-ACE-1.1 -- --int-arg some-arg:3 --bool-arg flag:true --string-arg text-arg:beef
```

## Testing

### Manual Testing
```bash
# Test 1: Extra args don't persist
th-cli run-tests -t TC-ACE-1.1 -- --endpoint 2
# Verify: Check that project config doesn't contain endpoint 2

# Test 2: Config file does persist
th-cli run-tests -t TC-ACE-1.1 --config test.json
# Verify: project config updated with test.json contents

# Test 3: Combined behavior
th-cli run-tests -t TC-ACE-1.1 --config base.json -- --int-arg some-arg:3
# Verify: project config has base.json, execution only uses base.json + int-arg 3
```

### Automated Testing
- Sanity tests pass ✅
- Unit Tests Ok ✅

---

**To Reviewers:** Please pay special attention to:
1. Unit Tests created
2. The `_parse_extra_args()` function logic
3. The temporary execution config feature
4. Documentation clarity