### PR TITLE
[Fix] ChipServer Info Display Not Showing

### DIFF
--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -166,9 +166,9 @@ class TestRunSocket:
 
             # Extract version, vendor_id and product_id from test_parameters if available
             test_parameters = self.project_config_dict.get("test_parameters", {})
-            version = test_parameters.get("version")
-            vendor_id = test_parameters.get("vendor_id")
-            product_id = test_parameters.get("product_id")
+            version = test_parameters.get("version") if test_parameters else None
+            vendor_id = test_parameters.get("vendor_id") if test_parameters else None
+            product_id = test_parameters.get("product_id") if test_parameters else None
 
             # Create API client and fetch chip server info
             client = get_client()


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/859
---

This change fix showing the CHIP Server Informations in the beginning of the CLI test execution when **not** using project ID or config options. Refer to the example in the image below:
 
<img width="864" height="426" alt="Screenshot 2026-01-29 at 15 33 40" src="https://github.com/user-attachments/assets/556b25c5-a6fa-42c3-a9d0-a0b93da63d78" />
