### PR TITLE
Fix WebSocket close handshake error for long-running test executions

### DIFF
--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -75,36 +75,42 @@ class TestRunSocket:
         self.test_case_step_errors: dict[tuple[int, int], list[str]] = {}
 
     async def connect_websocket(self) -> None:
+        try:
+            async with websocket_connect(
+                WEBSOCKET_URL,
+                ping_timeout=None,
+                close_timeout=10,  # Allow 10 seconds for close handshake
+                max_size=WEBSOCKET_MAX_MESSAGE_SIZE,
+                read_limit=WEBSOCKET_MAX_MESSAGE_SIZE,
+                write_limit=WEBSOCKET_MAX_MESSAGE_SIZE,
+            ) as socket:
+                try:
+                    while True:
+                        try:
+                            message = await socket.recv()
+                        except websockets.exceptions.ConnectionClosedOK:
+                            break
 
-        async with websocket_connect(
-            WEBSOCKET_URL,
-            ping_timeout=None,
-            max_size=WEBSOCKET_MAX_MESSAGE_SIZE,
-            read_limit=WEBSOCKET_MAX_MESSAGE_SIZE,
-            write_limit=WEBSOCKET_MAX_MESSAGE_SIZE,
-        ) as socket:
-            try:
-                while True:
-                    try:
-                        message = await socket.recv()
-                    except websockets.exceptions.ConnectionClosedOK:
-                        break
-
-                    # skip messages that are bytes, as we're expecting a string.\
-                    if not isinstance(message, str):
-                        click.echo(
-                            colorize_error("Failed to parse incoming websocket message. got bytes, expected text"),
-                            err=True,
-                        )
-                        continue
-                    try:
-                        message_obj = SocketMessage.parse_raw(message)
-                        await self.__handle_incoming_socket_message(socket=socket, message=message_obj)
-                    except ValidationError as e:
-                        click.echo(colorize_error(f"Received invalid socket message: {message}"), err=True)
-                        click.echo(colorize_error(e.json()), err=True)
-            finally:
-                pass  # Cleanup if needed
+                        # skip messages that are bytes, as we're expecting a string.\
+                        if not isinstance(message, str):
+                            click.echo(
+                                colorize_error("Failed to parse incoming websocket message. got bytes, expected text"),
+                                err=True,
+                            )
+                            continue
+                        try:
+                            message_obj = SocketMessage.parse_raw(message)
+                            await self.__handle_incoming_socket_message(socket=socket, message=message_obj)
+                        except ValidationError as e:
+                            click.echo(colorize_error(f"Received invalid socket message: {message}"), err=True)
+                            click.echo(colorize_error(e.json()), err=True)
+                finally:
+                    pass  # Cleanup if needed
+        except (websockets.exceptions.ConnectionClosedError, websockets.exceptions.ConnectionClosed):
+            # Handle case where backend doesn't complete close handshake properly
+            # This can happen with long-running test executions
+            # Error: "sent 1000 (OK); no close frame received"
+            pass
 
     async def __handle_incoming_socket_message(self, socket: WebSocketClientProtocol, message: SocketMessage) -> None:
         if isinstance(message.payload, TestUpdate):
@@ -141,7 +147,12 @@ class TestRunSocket:
             await self.__log_test_run_update(update.body)
             if update.body.state != "executing":
                 # Test run ended disconnect.
-                await socket.close()
+                try:
+                    await socket.close()
+                except websockets.exceptions.ConnectionClosedError:
+                    # Backend closed connection without completing handshake
+                    # This is acceptable as test run completed successfully
+                    pass
 
     async def __log_test_run_update(self, update: TestRunUpdate) -> None:
         # Display CHIP server info when test run starts executing (SDK container already running)

--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -106,7 +106,7 @@ class TestRunSocket:
                             click.echo(colorize_error(e.json()), err=True)
                 finally:
                     pass  # Cleanup if needed
-        except (websockets.exceptions.ConnectionClosedError, websockets.exceptions.ConnectionClosed):
+        except websockets.exceptions.ConnectionClosed:
             # Handle case where backend doesn't complete close handshake properly
             # This can happen with long-running test executions
             # Error: "sent 1000 (OK); no close frame received"


### PR DESCRIPTION
### What changed
 Fix WebSocket close handshake error for long-running test executions in the CLI. This change prevents the error message "sent 1000 (OK); no close frame received" from appearing after successful test completion.

  Changes

  WebSocket Connection Management:
  - Added close_timeout=10 parameter to websocket_connect() to allow 10 seconds for the close handshake to complete
  - Wrapped the entire async with websocket_connect() context manager in a try-except block to catch ConnectionClosedError and ConnectionClosed exceptions
  - Added exception handling around the explicit socket.close() call in __handle_test_update() method

  Exception Handling:
  - Gracefully suppresses WebSocket close handshake errors that occur when the backend doesn't respond with a close frame
  - Added inline comments explaining that these errors are expected with long-running test executions

  Motivation

  Problem:
  When running long test executions (e.g., TC-ACE-2.1) via the CLI, users would see the error message "Error: Unexpected error during test execution: sent 1000 (OK); no close frame received" even though the test completed successfully and showed as PASSED. This error did not occur when running tests through the TH UI.

  Root Cause:
  - During long-running test executions, the backend server sometimes fails to complete the WebSocket close handshake properly
  - When the CLI sends a close frame (status code 1000 - normal closure), the backend may not respond with its own close frame
  - This causes the WebSocket library to raise a ConnectionClosedError exception, which was propagating up to the user

  Solution:
  - Added a close_timeout to give the backend more time to respond during the close handshake
  - Added exception handling to suppress the error when the backend doesn't complete the handshake properly, since this is a cosmetic issue that doesn't affect test results

  Impact

  User Experience:
  - ✅ Tests will complete cleanly without confusing error messages
  - ✅ Test results remain accurate and show correct PASS/FAIL status
  - ✅ No breaking changes to existing functionality

  Technical:
  - The 10-second close timeout is reasonable for long-running tests and won't impact performance
  - Exception handling is specific to connection close errors and won't mask other legitimate errors
  - Changes are isolated to the WebSocket connection handling code

### Related Issue
https://github.com/project-chip/certification-tool/issues/866

### Testing
  - Verified with TC-ACE-2.1, 2.2 & 2.4 test execution
  - Error message no longer appears while test results remain accurate