### PR TITLE
fix: Update regex to support TC-I-XXX tests in CLI

### DIFF
--- a/th_cli/validation.py
+++ b/th_cli/validation.py
@@ -96,7 +96,7 @@ def validate_test_ids(test_ids: str) -> list[str]:
         raise CLIError("No valid test IDs provided")
 
     # Validate each test ID format
-    valid_pattern = re.compile(r"^TC[-_][A-Z_]{2,20}([-_\.]\d+){2,3}(-custom)?$")
+    valid_pattern = re.compile(r"^TC[-_][A-Z_]{1,20}([-_\.]\d+){2,3}(-custom)?$")
 
     invalid_ids = []
     for test_id in ids:


### PR DESCRIPTION
What this PR does:
This PR updates the regex pattern to properly handle test cases like TC-I-XXX.

Why it is needed:
Previously, running these specific tests via the CLI tool threw an error because the regex did not match the test case format correctly.

Fixes [#873](https://github.com/project-chip/certification-tool/issues/873#issuecomment-4028715907)