### PR TITLE
Fix test case comparison logic

### DIFF
--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -162,7 +162,7 @@ def load_json_config(config_path: str) -> dict[str, Any]:
     except FileNotFoundError as e:
         handle_file_error(e, "config file")
     except json.JSONDecodeError as e:
-        raise CLIError(f"Invalid JSON in config file '{config_path}': {e.msg} " f"(line {e.lineno}, column {e.colno})")
+        raise CLIError(f"Invalid JSON in config file '{config_path}': {e.msg} (line {e.lineno}, column {e.colno})")
     except OSError as e:
         raise CLIError(f"Failed to read config file '{config_path}': {e}")
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -74,8 +74,8 @@ def build_test_selection(test_collections, tests_list) -> dict:
     """
     selected_tests = {}
 
-    # Convert test IDs to a set for faster lookup and normalize them
-    tests_set = {test_id.strip().replace("-", "_").replace(".", "_") for test_id in tests_list}
+    # Convert test IDs to a set for faster lookup and normalize them (case-insensitive)
+    tests_set = {test_id.strip().replace("-", "_").replace(".", "_").upper() for test_id in tests_list}
 
     # Iterate through test collections
     for collection_name, collection in test_collections.test_collections.items():
@@ -87,8 +87,8 @@ def build_test_selection(test_collections, tests_list) -> dict:
 
             # Iterate through test cases
             for test_case_id, test_case in suite.test_cases.items():
-                # Normalize the test case ID for comparison
-                normalized_test_case_id = test_case_id.replace("-", "_").replace(".", "_")
+                # Normalize the test case ID for comparison (case-insensitive)
+                normalized_test_case_id = test_case_id.replace("-", "_").replace(".", "_").upper()
                 if normalized_test_case_id in tests_set:
                     selected_tests[collection_name][suite_name][test_case_id] = 1
 
@@ -162,10 +162,7 @@ def load_json_config(config_path: str) -> dict[str, Any]:
     except FileNotFoundError as e:
         handle_file_error(e, "config file")
     except json.JSONDecodeError as e:
-        raise CLIError(
-            f"Invalid JSON in config file '{config_path}': {e.msg} "
-            f"(line {e.lineno}, column {e.colno})"
-        )
+        raise CLIError(f"Invalid JSON in config file '{config_path}': {e.msg} " f"(line {e.lineno}, column {e.colno})")
     except OSError as e:
         raise CLIError(f"Failed to read config file '{config_path}': {e}")
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -162,7 +162,10 @@ def load_json_config(config_path: str) -> dict[str, Any]:
     except FileNotFoundError as e:
         handle_file_error(e, "config file")
     except json.JSONDecodeError as e:
-        raise CLIError(f"Invalid JSON in config file '{config_path}': {e.msg} (line {e.lineno}, column {e.colno})")
+        raise CLIError(
+            f"Invalid JSON in config file '{config_path}': {e.msg} "
+            f"(line {e.lineno}, column {e.colno})"
+        )
     except OSError as e:
         raise CLIError(f"Failed to read config file '{config_path}': {e}")
 


### PR DESCRIPTION
### What changed
Fixes a bug in the CLI where test IDs with mixed-case letters (e.g. TC_WebRTCP_2_2) were not matched when the user provided a different case variant (e.g. TC_WEBRTCP_2_2), causing the test run to end as NOT_APPLICABLE. 


### Related Issue
https://github.com/project-chip/certification-tool/issues/902

### Testing
Running `th-cli run-tests -t TC_WEBRTCP_2_2 --project-id 11` no longer results in `NOT_APPLICABLE` due to test not found.  
<img width="957" height="602" alt="Screenshot 2026-03-04 at 19 43 06" src="https://github.com/user-attachments/assets/2be2f32f-a70b-47fe-ae0e-adc6a6f9fa7a" />

TC_WEBRTCP_2_1  running successfully with this command: `th-cli run-tests --tests-list TC_WEBRTCP_2_1 --project-id 1`
<img width="910" height="561" alt="Screenshot 2026-03-05 at 14 11 55" src="https://github.com/user-attachments/assets/21dfd7b0-c481-4ff5-a598-c3c18c6ff490" />

