### PR TITLE
Add missing image_handler.py and image_verification.html for snapshot camera verification                                               

### DIFF
--- a/th_cli/test_run/camera/image_handler.py
+++ b/th_cli/test_run/camera/image_handler.py
@@ -45,7 +45,6 @@ class ImageVerificationHTTPHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
@@ -68,10 +67,11 @@ class ImageVerificationHTTPHandler(BaseHTTPRequestHandler):
 
         radio_options_html = ""
         for key, value in prompt_options.items():
+            safe_value = int(value)
             radio_options_html += f"""
-            <div class="popup-radio-row" data-value="{value}" onclick="selectOption({value})">
-                <input type="radio" name="option" value="{value}" id="radio_{value}">
-                <label for="radio_{value}">{html.escape(key)}</label>
+            <div class="popup-radio-row" data-value="{safe_value}" onclick="selectOption({safe_value})">
+                <input type="radio" name="option" value="{safe_value}" id="radio_{safe_value}">
+                <label for="radio_{safe_value}">{html.escape(key)}</label>
             </div>
             """
 
@@ -108,35 +108,30 @@ class ImageVerificationHTTPHandler(BaseHTTPRequestHandler):
 
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(b'{"status": "success"}')
         except (json.JSONDecodeError, UnicodeDecodeError) as e:
             logger.error(f"Malformed request body: {e}")
             self.send_response(400)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(json.dumps({"error": f"Invalid JSON: {e}"}).encode())
         except KeyError as e:
             logger.error(f"Missing required field in request: {e}")
             self.send_response(400)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(json.dumps({"error": f"Missing field: {e}"}).encode())
         except ValueError as e:
             logger.error(f"Invalid value in request: {e}")
             self.send_response(400)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(json.dumps({"error": f"Invalid value: {e}"}).encode())
         except Exception as e:
             logger.error(f"Unexpected error handling image verification response: {e}")
             self.send_response(500)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(json.dumps({"error": str(e)}).encode())
 

--- a/th_cli/test_run/camera/image_handler.py
+++ b/th_cli/test_run/camera/image_handler.py
@@ -1,0 +1,182 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import asyncio
+import html
+import json
+import queue
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+
+
+class ImageVerificationHTTPHandler(BaseHTTPRequestHandler):
+    """HTTP handler for serving a snapshot image and collecting user pass/fail response."""
+
+    def do_GET(self):
+        if self.path == "/":
+            self._serve_page()
+        elif self.path == "/image":
+            self._serve_image()
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path == "/submit_response":
+            self._handle_response()
+        else:
+            self.send_error(404)
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def _serve_image(self):
+        image_data = getattr(self.server, "image_data", None)
+        if not image_data:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "image/jpeg")
+        self.send_header("Content-Length", str(len(image_data)))
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        self.wfile.write(image_data)
+
+    def _serve_page(self):
+        prompt_text = getattr(self.server, "prompt_text", "Verify the snapshot image")
+        prompt_options = getattr(self.server, "prompt_options", {})
+
+        radio_options_html = ""
+        for key, value in prompt_options.items():
+            radio_options_html += f"""
+            <div class="popup-radio-row" data-value="{value}" onclick="selectOption({value})">
+                <input type="radio" name="option" value="{value}" id="radio_{value}">
+                <label for="radio_{value}">{html.escape(key)}</label>
+            </div>
+            """
+
+        try:
+            template_path = Path(__file__).parent / "image_verification.html"
+            with open(template_path, "r", encoding="utf-8") as f:
+                html_template = f.read()
+            page = html_template.format(
+                prompt_text=html.escape(prompt_text),
+                radio_options_html=radio_options_html,
+            )
+        except Exception as e:
+            logger.error(f"Failed to load image verification HTML template: {e}")
+            page = f"<html><body><h1>Error loading template</h1><p>{e}</p></body></html>"
+
+        encoded = page.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _handle_response(self):
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+            post_data = self.rfile.read(content_length)
+            data = json.loads(post_data.decode("utf-8"))
+            response_value = int(data["response"])
+
+            response_queue = getattr(self.server, "response_queue", None)
+            if response_queue:
+                response_queue.put_nowait(response_value)
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(b'{"status": "success"}')
+        except Exception as e:
+            logger.error(f"Error handling image verification response: {e}")
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": str(e)}).encode())
+
+    def log_message(self, format, *args):
+        pass  # Suppress HTTP logs
+
+
+class ImageVerificationHandler:
+    """Serves a snapshot image via HTTP and waits for user pass/fail response."""
+
+    def __init__(self, port: int = 8999):
+        self.port = port
+        self.http_server: Optional[ThreadingHTTPServer] = None
+        self._server_thread: Optional[threading.Thread] = None
+        self._response_queue: queue.Queue = queue.Queue()
+
+    def set_prompt_data(self, prompt_text: str, options: dict, image_data: bytes):
+        self._prompt_text = prompt_text
+        self._options = options
+        self._image_data = image_data
+
+    async def start_image_server(self, prompt_id: str):
+        """Start the HTTP server to serve the image page."""
+        server = ThreadingHTTPServer(("0.0.0.0", self.port), ImageVerificationHTTPHandler)
+        server.allow_reuse_address = True
+        server.image_data = self._image_data
+        server.prompt_text = getattr(self, "_prompt_text", "Verify the snapshot image")
+        server.prompt_options = getattr(self, "_options", {})
+        server.response_queue = self._response_queue
+        server.port = self.port
+        self.http_server = server
+
+        def _run():
+            logger.info(f"Image verification HTTP server starting on port {self.port}")
+            try:
+                self.http_server.serve_forever()
+            except Exception as e:
+                logger.error(f"Image HTTP server error: {e}")
+
+        self._server_thread = threading.Thread(target=_run, daemon=True)
+        self._server_thread.start()
+        logger.info(f"Image verification server started on port {self.port}")
+
+    async def wait_for_user_response(self, timeout: float) -> Optional[int]:
+        """Wait for user response from the web UI."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                return self._response_queue.get_nowait()
+            except queue.Empty:
+                await asyncio.sleep(0.1)
+        logger.warning("Image verification response timed out")
+        return None
+
+    def stop_image_server(self):
+        """Stop the HTTP server."""
+        if self.http_server:
+            try:
+                self.http_server.shutdown()
+            except Exception as e:
+                logger.debug(f"Error stopping image HTTP server: {e}")
+            finally:
+                self.http_server = None
+                self._server_thread = None

--- a/th_cli/test_run/camera/image_handler.py
+++ b/th_cli/test_run/camera/image_handler.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/th_cli/test_run/camera/image_handler.py
+++ b/th_cli/test_run/camera/image_handler.py
@@ -83,7 +83,7 @@ class ImageVerificationHTTPHandler(BaseHTTPRequestHandler):
                 prompt_text=html.escape(prompt_text),
                 radio_options_html=radio_options_html,
             )
-        except Exception as e:
+        except (FileNotFoundError, IOError) as e:
             logger.error(f"Failed to load image verification HTML template: {e}")
             page = f"<html><body><h1>Error loading template</h1><p>{e}</p></body></html>"
 
@@ -111,8 +111,29 @@ class ImageVerificationHTTPHandler(BaseHTTPRequestHandler):
             self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(b'{"status": "success"}')
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            logger.error(f"Malformed request body: {e}")
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": f"Invalid JSON: {e}"}).encode())
+        except KeyError as e:
+            logger.error(f"Missing required field in request: {e}")
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": f"Missing field: {e}"}).encode())
+        except ValueError as e:
+            logger.error(f"Invalid value in request: {e}")
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": f"Invalid value: {e}"}).encode())
         except Exception as e:
-            logger.error(f"Error handling image verification response: {e}")
+            logger.error(f"Unexpected error handling image verification response: {e}")
             self.send_response(500)
             self.send_header("Content-Type", "application/json")
             self.send_header("Access-Control-Allow-Origin", "*")
@@ -137,7 +158,7 @@ class ImageVerificationHandler:
         self._options = options
         self._image_data = image_data
 
-    async def start_image_server(self, prompt_id: str):
+    async def start_image_server(self):
         """Start the HTTP server to serve the image page."""
         server = ThreadingHTTPServer(("0.0.0.0", self.port), ImageVerificationHTTPHandler)
         server.allow_reuse_address = True

--- a/th_cli/test_run/camera/image_verification.html
+++ b/th_cli/test_run/camera/image_verification.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Snapshot Image Verification</title>
+    <style>
+        body {{
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f5f5f5;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }}
+
+        .matter-header {{
+            background: white;
+            border-bottom: 1px solid #e0e0e0;
+            padding: 12px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+
+        .header-start {{
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }}
+
+        .header-title {{
+            font-size: 18px;
+            font-weight: 600;
+            color: #333;
+            margin: 0;
+        }}
+
+        .header-end {{
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }}
+
+        .version-info {{
+            font-size: 12px;
+            color: #666;
+            text-align: right;
+        }}
+
+        .cli-indicator {{
+            background: #2196F3;
+            color: white;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 500;
+        }}
+
+        .main-content {{
+            flex: 1;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+        }}
+
+        .p-dialog {{
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+            max-width: 700px;
+            width: 100%;
+            margin: 20px;
+        }}
+
+        .p-dialog-header {{
+            padding: 16px 20px;
+            border-bottom: 1px solid #e0e0e0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: #fafafa;
+            border-radius: 8px 8px 0 0;
+        }}
+
+        .p-dialog-title {{
+            font-size: 18px;
+            font-weight: 600;
+            color: #333;
+        }}
+
+        .p-dialog-content {{
+            padding: 20px;
+        }}
+
+        .subheader {{
+            font-size: 16px;
+            color: #555;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }}
+
+        .image-container {{
+            text-align: center;
+            margin: 20px 0;
+            background: #000;
+            border-radius: 4px;
+            padding: 10px;
+        }}
+
+        .image-container img {{
+            max-width: 640px;
+            max-height: 480px;
+            width: 100%;
+            border: 2px solid #ddd;
+            border-radius: 4px;
+            background: #000;
+        }}
+
+        .input-items-div {{
+            margin: 20px 0;
+        }}
+
+        .popup-radio-div {{
+            display: flex;
+            gap: 20px;
+            justify-content: center;
+            margin: 20px 0;
+            flex-wrap: wrap;
+        }}
+
+        .popup-radio-row {{
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.2s;
+            min-width: 100px;
+            justify-content: center;
+        }}
+
+        .popup-radio-row:hover {{
+            background: #f0f0f0;
+            border-color: #2196F3;
+        }}
+
+        .popup-radio-row.selected {{
+            background: #e3f2fd;
+            border-color: #2196F3;
+        }}
+
+        input[type="radio"] {{
+            margin-right: 8px;
+            transform: scale(1.2);
+        }}
+
+        label {{
+            font-weight: 500;
+            color: #333;
+            cursor: pointer;
+            font-size: 14px;
+        }}
+
+        .buttons-div {{
+            text-align: center;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e0e0e0;
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }}
+
+        .popup-button {{
+            background: #2196F3;
+            color: white;
+            border: none;
+            padding: 12px 30px;
+            border-radius: 4px;
+            font-size: 16px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s;
+            min-width: 120px;
+        }}
+
+        .popup-button:hover {{
+            background: #1976D2;
+        }}
+
+        .popup-button:disabled {{
+            background: #ccc;
+            cursor: not-allowed;
+        }}
+
+        .status-info {{
+            background: #e8f5e8;
+            border: 1px solid #4caf50;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+            font-size: 14px;
+            color: #2e7d32;
+        }}
+
+        .submitting {{
+            background: #ff9800 !important;
+            cursor: wait !important;
+        }}
+    </style>
+    <script>
+        let selectedValue = null;
+
+        function selectOption(value) {{
+            selectedValue = value;
+
+            document.querySelectorAll('.popup-radio-row').forEach(row => {{
+                row.classList.remove('selected');
+            }});
+            document.querySelector(`[data-value="${{value}}"]`).classList.add('selected');
+
+            document.querySelectorAll('input[type="radio"]').forEach(radio => {{
+                radio.checked = radio.value === value.toString();
+            }});
+
+            document.getElementById('submitBtn').disabled = false;
+        }}
+
+        async function submitResponse() {{
+            if (selectedValue) {{
+                const button = document.getElementById('submitBtn');
+                button.classList.add('submitting');
+                button.textContent = 'Submitting...';
+                button.disabled = true;
+
+                try {{
+                    const response = await fetch('/submit_response', {{
+                        method: 'POST',
+                        headers: {{ 'Content-Type': 'application/json' }},
+                        body: JSON.stringify({{ response: selectedValue }})
+                    }});
+
+                    if (response.ok) {{
+                        button.textContent = 'Response Sent!';
+                        button.style.background = '#4caf50';
+                        setTimeout(() => {{
+                            button.textContent = 'Complete';
+                            button.disabled = true;
+                        }}, 1000);
+                    }} else {{
+                        const errorText = await response.text();
+                        throw new Error(`Server error: ${{response.status}} - ${{errorText}}`);
+                    }}
+                }} catch (error) {{
+                    console.error('Error submitting response:', error);
+                    button.textContent = 'Error - Try Again';
+                    button.style.background = '#f44336';
+                    button.disabled = false;
+                    button.classList.remove('submitting');
+                    setTimeout(() => {{
+                        button.textContent = 'Submit';
+                        button.style.background = '#2196F3';
+                    }}, 3000);
+                }}
+            }}
+        }}
+    </script>
+</head>
+<body>
+    <div class="matter-header">
+        <div class="header-start">
+            <div class="header-title">Matter Certification Tool</div>
+        </div>
+        <div class="header-end">
+            <div class="cli-indicator">CLI</div>
+            <div class="version-info">
+                <div>Image Verification</div>
+                <div style="font-size: 10px; color: #999;">CLI Snapshot Interface</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="main-content">
+        <div class="p-dialog" role="dialog">
+            <div class="p-dialog-header">
+                <span class="p-dialog-title">Snapshot Image Verification</span>
+            </div>
+
+            <div class="p-dialog-content">
+                <div class="subheader">
+                    {prompt_text}
+                </div>
+
+                <div class="status-info">
+                    &#128248; Snapshot captured from DUT &mdash; verify the image below
+                </div>
+
+                <div class="image-container">
+                    <img src="/image" alt="Snapshot image" />
+                </div>
+
+                <div class="input-items-div">
+                    <div class="popup-radio-div">
+                        {radio_options_html}
+                    </div>
+                </div>
+
+                <div class="buttons-div">
+                    <button id="submitBtn" class="popup-button" onclick="submitResponse()" disabled>
+                        Submit
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -205,7 +205,7 @@ async def _handle_image_verification_prompt(
         image_handler.set_prompt_data(prompt.prompt, prompt.options, image_data)
 
         # Start HTTP server
-        await image_handler.start_image_server(str(prompt.message_id))
+        await image_handler.start_image_server()
 
         # Show user instructions
         local_ip = _get_local_ip()


### PR DESCRIPTION
### What Changed
- Add th_cli/test_run/camera/image_handler.py — implements ImageVerificationHandler, which starts a local HTTP server to serve the captured snapshot image and waits for a user PASS/FAIL response via the web UI
  - Add th_cli/test_run/camera/image_verification.html — HTML template rendered by the server, showing the snapshot and radio-button options for the user to submit a response
  - Export ImageVerificationHandler from th_cli/test_run/camera/__init__.py so it is importable by prompt_manager.py

### Related Issue
https://github.com/project-chip/certification-tool/issues/908

### Testing
CLI is able to run TC-AVSM-2.10.
In order to reproduce the issue, I performed the command bellow since I don't have a proper DUT to perform the test run execution:` gst-launch-1.0 v4l2src device=/dev/video0 num-buffers=1 ! videoconvert ! jpegenc ! filesink location=./capture_snapshot.jpg` and `rm -rf /tmp/chip_*;./chip-camera-app`

<img width="736" height="619" alt="Screenshot 2026-03-09 at 15 24 15" src="https://github.com/user-attachments/assets/86c4cc54-f44e-418f-b5b5-64dd9762059d" />
