### PR TITLE
[FIX] Run_Tests Command Configuration Logic

### DIFF
--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -146,15 +146,15 @@ async def run_tests(
         project_config_dict = convert_nested_to_dict(project_config)
         click.echo(colorize_key_value("Project Config", project_config_dict))
 
-        # Create execution config starting from project config
-        # This ensures we don't modify the original project config
-        test_run_config = copy.deepcopy(project_config_dict)
-
-        # If config file is provided, merge it into execution config only
+        # Create execution config. If a config file is provided, merge it with the
+        # project config. Otherwise, just use a copy of the project config.
+        # This avoids modifying the original project_config_dict.
         if config:
             config_data = load_json_config(config)
-            test_run_config = merge_configs(test_run_config, config_data)
+            test_run_config = merge_configs(project_config_dict, config_data)
             click.echo(colorize_key_value("CLI Test Run Execution Config", test_run_config))
+        else:
+            test_run_config = copy.deepcopy(project_config_dict)
 
         # Merge extra test parameters if provided (temporary for this execution only)
         if extra_test_params:

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -146,15 +146,15 @@ async def run_tests(
         project_config_dict = convert_nested_to_dict(project_config)
         click.echo(colorize_key_value("Project Config", project_config_dict))
 
-        # If config file is provided, read JSON config and merge into project config
+        # Create execution config starting from project config
+        # This ensures we don't modify the original project config
+        test_run_config = copy.deepcopy(project_config_dict)
+
+        # If config file is provided, merge it into execution config only
         if config:
             config_data = load_json_config(config)
-            project_config_dict = merge_configs(project_config_dict, config_data)
-            click.echo(colorize_key_value("CLI Test Run Execution Config", project_config_dict))
-
-        # Create a DEEP copy for this test run execution to avoid modifying the original
-        # This ensures extra parameters only apply to THIS run, not future runs
-        test_run_config = copy.deepcopy(project_config_dict)
+            test_run_config = merge_configs(test_run_config, config_data)
+            click.echo(colorize_key_value("CLI Test Run Execution Config", test_run_config))
 
         # Merge extra test parameters if provided (temporary for this execution only)
         if extra_test_params:


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/910
---

## Description

The `run-tests` CLI command was carrying over `test_parameters` configuration from one execution to the next when using config files. This caused test parameters specified via `--config` to persist to the project configuration and affect subsequent test runs, even when those parameters shouldn't be applied.

## Root Cause

The bug was in the configuration handling flow in [`run_tests.py`](cli/th_cli/commands/run_tests.py):

1. When a config file was provided via `--config`, it was merged directly into `project_config_dict` (line 159)
2. This merged dictionary was then passed as the `config` parameter to `_create_new_test_run_cli()` (line 190)
3. According to the function's docstring, the `config` parameter represents "Optional configuration that updates project (persistent)", meaning it persists changes to the backend project configuration
4. As a result, `test_parameters` from the config file were saved to the project and carried over to future test runs

### Solution

Restructured the configuration handling to properly separate:
- **Project config**: Original, unmodified configuration from the backend
- **Execution config**: Temporary configuration that includes merged config file and extra test parameters

**Changes made:**

1. **Preserve original project config** (lines 151-154): Keep `project_config_dict` unmodified after retrieval
2. **Create separate execution config** (lines 156-162): Create `test_run_config` as a deep copy, then merge config file into it only
3. **Apply extra params to execution config** (lines 166-174): Merge extra test parameters into `test_run_config` only
4. **Pass correct configs to API** (lines 190-191):
   - `config=project_config_dict`: Original project config (no temporary settings)
   - `execution_config=test_run_config`: Fully merged config (temporary, includes all overrides)

### Testing

To verify the fix:
1. Run a test with a config file containing test parameters
2. Run another test without the config file
3. Confirm that the second test doesn't inherit the test parameters from the first run

```bash
# First run with config
th-cli run-tests -t TC-ACE-1.1 --config config_with_params.json

# Second run without config
th-cli run-tests -t TC-ACE-1.2

# Test parameters from config_with_params.json should NOT carry over to second run
```
