### PR TITLE
CLI  to support two way talk tests

### DIFF
--- a/tests/test_run/camera/test_two_way_talk_handler.py
+++ b/tests/test_run/camera/test_two_way_talk_handler.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Unit tests for TwoWayTalkHandler and module-level helpers."""
+"""Unit tests for TwoWayTalkHandler and TwoWayTalkHTTPHandler."""
 
 import asyncio
 import json
@@ -26,13 +26,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 import th_cli.test_run.camera.two_way_talk_handler as _module
-from th_cli.test_run.camera.two_way_talk_handler import (
-    TwoWayTalkHandler,
-    TwoWayTalkHTTPHandler,
-    get_active_handler,
-    set_active_handler,
-    show_prompt_on_active_server,
-)
+from th_cli.test_run.camera.two_way_talk_handler import TwoWayTalkHandler, TwoWayTalkHTTPHandler
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -131,14 +125,6 @@ class TestTwoWayTalkHandlerStart:
                     getattr(h, method)()
         return h, mock_srv, mock_thread
 
-    def test_start_waiting_registers_active_handler(self):
-        h, _, _ = self._patched_start("start_waiting")
-        assert get_active_handler() is h
-
-    def test_start_server_only_registers_active_handler(self):
-        h, _, _ = self._patched_start("start_server_only")
-        assert get_active_handler() is h
-
     def test_server_thread_is_started(self):
         _, _, mock_thread = self._patched_start()
         mock_thread.start.assert_called_once()
@@ -153,10 +139,6 @@ class TestTwoWayTalkHandlerStart:
         h, mock_srv, _ = self._patched_start()
         assert mock_srv.response_queue is h._response_queue
         assert mock_srv.browser_ready_event is h._browser_ready_event
-
-    def test_module_level_active_server_set(self):
-        h, mock_srv, _ = self._patched_start()
-        assert _module._active_server is mock_srv
 
     def test_start_waiting_calls_free_port(self):
         h = TwoWayTalkHandler(port=9001)
@@ -298,13 +280,12 @@ class TestTwoWayTalkHandlerWaitForUserResponse:
 
 @pytest.mark.unit
 class TestTwoWayTalkHandlerStop:
-    """Positive + edge: stop shuts down server and clears global state."""
+    """Positive + edge: stop shuts down server and clears server reference."""
 
     def test_stop_calls_server_shutdown(self):
         h = TwoWayTalkHandler(port=0)
         mock_srv = Mock()
         h._server = mock_srv
-        set_active_handler(h)
 
         h.stop()
 
@@ -315,21 +296,6 @@ class TestTwoWayTalkHandlerStop:
         h._server = Mock()
         h.stop()
         assert h._server is None
-
-    def test_stop_clears_active_handler(self):
-        h = TwoWayTalkHandler(port=0)
-        h._server = Mock()
-        set_active_handler(h)
-        h.stop()
-        assert get_active_handler() is None
-
-    def test_stop_clears_module_level_active_server(self):
-        h = TwoWayTalkHandler(port=0)
-        mock_srv = Mock()
-        h._server = mock_srv
-        _module._active_server = mock_srv
-        h.stop()
-        assert _module._active_server is None
 
     def test_stop_is_noop_when_server_is_none(self):
         h = TwoWayTalkHandler(port=0)
@@ -361,41 +327,6 @@ class TestTwoWayTalkHandlerStartAlias:
                 h.start("Verify", {"PASS": 1})
         mock_wait.assert_called_once()
         mock_show.assert_called_once_with("Verify", {"PASS": 1})
-
-
-# ---------------------------------------------------------------------------
-# Module-level helpers
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestModuleLevelHelpers:
-    """Positive + negative: get/set active handler and show_prompt_on_active_server."""
-
-    def test_set_and_get_active_handler(self):
-        h = TwoWayTalkHandler(port=0)
-        set_active_handler(h)
-        assert get_active_handler() is h
-        set_active_handler(None)  # cleanup
-
-    def test_set_active_handler_to_none(self):
-        set_active_handler(None)
-        assert get_active_handler() is None
-
-    def test_show_prompt_on_active_server_returns_true_when_server_exists(self):
-        mock_srv = Mock()
-        _module._active_server = mock_srv
-        result = show_prompt_on_active_server("Hello", {"PASS": 1})
-        assert result is True
-        assert mock_srv.prompt_text == "Hello"
-        assert mock_srv.prompt_options == {"PASS": 1}
-        assert mock_srv.prompt_ready is True
-        _module._active_server = None  # cleanup
-
-    def test_show_prompt_on_active_server_returns_false_when_no_server(self):
-        _module._active_server = None
-        result = show_prompt_on_active_server("Hello", {})
-        assert result is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run/camera/test_two_way_talk_handler.py
+++ b/tests/test_run/camera/test_two_way_talk_handler.py
@@ -1,0 +1,621 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for TwoWayTalkHandler and module-level helpers."""
+
+import asyncio
+import json
+import queue
+import threading
+import time
+from io import BytesIO
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+import th_cli.test_run.camera.two_way_talk_handler as _module
+from th_cli.test_run.camera.two_way_talk_handler import (
+    TwoWayTalkHandler,
+    TwoWayTalkHTTPHandler,
+    get_active_handler,
+    set_active_handler,
+    show_prompt_on_active_server,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_handler(path="/", method="GET", headers=None, body=b"", server_attrs=None):
+    """Build a TwoWayTalkHTTPHandler without a real socket.
+
+    Bypasses __init__ (which parses a live HTTP request) and injects
+    the attributes required by each method under test.
+    """
+    handler = TwoWayTalkHTTPHandler.__new__(TwoWayTalkHTTPHandler)
+    handler.path = path
+    handler.command = method
+
+    mock_headers = MagicMock()
+    mock_headers.__contains__ = lambda self, key: key in (headers or {})
+    mock_headers.__getitem__ = lambda self, key: (headers or {})[key]
+    mock_headers.get = lambda key, default=None: (headers or {}).get(key, default)
+    handler.headers = mock_headers
+
+    handler.rfile = BytesIO(body)
+    handler.wfile = BytesIO()
+
+    mock_server = MagicMock()
+    for attr, value in (server_attrs or {}).items():
+        setattr(mock_server, attr, value)
+    handler.server = mock_server
+
+    handler._response_code = None
+    handler._headers_sent = {}
+    handler._error_code = None
+
+    handler.send_response = lambda code, msg=None: setattr(handler, "_response_code", code)
+    handler.send_header = lambda k, v: handler._headers_sent.__setitem__(k, v)
+    handler.end_headers = lambda: None
+    handler.send_error = lambda code, msg=None: setattr(handler, "_error_code", code)
+
+    return handler
+
+
+def _make_twt_handler(port=0):
+    """Return a TwoWayTalkHandler with server patched so no real port is bound."""
+    return TwoWayTalkHandler(port=port)
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerInit:
+    """Positive: constructor stores port and initialises internal state."""
+
+    def test_default_port(self):
+        h = TwoWayTalkHandler()
+        assert h.port == 8999
+
+    def test_custom_port_stored(self):
+        h = TwoWayTalkHandler(port=1234)
+        assert h.port == 1234
+
+    def test_server_initially_none(self):
+        h = TwoWayTalkHandler(port=0)
+        assert h._server is None
+
+    def test_response_queue_initially_empty(self):
+        h = TwoWayTalkHandler(port=0)
+        assert h._response_queue.empty()
+
+    def test_browser_ready_event_initially_clear(self):
+        h = TwoWayTalkHandler(port=0)
+        assert not h._browser_ready_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — start_waiting / start_server_only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerStart:
+    """Positive: server is created and registered after start."""
+
+    def _patched_start(self, method="start_waiting"):
+        h = TwoWayTalkHandler(port=0)
+        mock_srv = Mock()
+        with patch("th_cli.test_run.camera.two_way_talk_handler._ReuseAddrHTTPServer") as mock_cls:
+            mock_cls.return_value = mock_srv
+            with patch("th_cli.test_run.camera.two_way_talk_handler.threading.Thread") as mock_thread_cls:
+                mock_thread = Mock()
+                mock_thread_cls.return_value = mock_thread
+                with patch.object(TwoWayTalkHandler, "_free_port"):
+                    getattr(h, method)()
+        return h, mock_srv, mock_thread
+
+    def test_start_waiting_registers_active_handler(self):
+        h, _, _ = self._patched_start("start_waiting")
+        assert get_active_handler() is h
+
+    def test_start_server_only_registers_active_handler(self):
+        h, _, _ = self._patched_start("start_server_only")
+        assert get_active_handler() is h
+
+    def test_server_thread_is_started(self):
+        _, _, mock_thread = self._patched_start()
+        mock_thread.start.assert_called_once()
+
+    def test_server_attributes_initialised(self):
+        _, mock_srv, _ = self._patched_start()
+        assert mock_srv.prompt_ready is False
+        assert mock_srv.prompt_text == "Verify two-way talk"
+        assert mock_srv.prompt_options == {}
+
+    def test_server_queues_attached(self):
+        h, mock_srv, _ = self._patched_start()
+        assert mock_srv.response_queue is h._response_queue
+        assert mock_srv.browser_ready_event is h._browser_ready_event
+
+    def test_module_level_active_server_set(self):
+        h, mock_srv, _ = self._patched_start()
+        assert _module._active_server is mock_srv
+
+    def test_start_waiting_calls_free_port(self):
+        h = TwoWayTalkHandler(port=9001)
+        with patch("th_cli.test_run.camera.two_way_talk_handler._ReuseAddrHTTPServer", return_value=Mock()):
+            with patch("th_cli.test_run.camera.two_way_talk_handler.threading.Thread", return_value=Mock()):
+                with patch.object(TwoWayTalkHandler, "_free_port") as mock_free:
+                    h.start_waiting()
+        mock_free.assert_called_once_with(9001)
+
+    def test_start_server_only_does_not_call_free_port(self):
+        h = TwoWayTalkHandler(port=9001)
+        with patch("th_cli.test_run.camera.two_way_talk_handler._ReuseAddrHTTPServer", return_value=Mock()):
+            with patch("th_cli.test_run.camera.two_way_talk_handler.threading.Thread", return_value=Mock()):
+                with patch.object(TwoWayTalkHandler, "_free_port") as mock_free:
+                    h.start_server_only()
+        mock_free.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — show_prompt / update_prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerShowPrompt:
+    """Positive: show_prompt updates server state; no-op when server is None."""
+
+    def _started_handler(self):
+        h = TwoWayTalkHandler(port=0)
+        mock_srv = Mock()
+        mock_srv.prompt_ready = False
+        h._server = mock_srv
+        return h, mock_srv
+
+    def test_show_prompt_sets_prompt_text(self):
+        h, mock_srv = self._started_handler()
+        h.show_prompt("Is it working?", {"PASS": 1, "FAIL": 2})
+        assert mock_srv.prompt_text == "Is it working?"
+
+    def test_show_prompt_sets_prompt_options(self):
+        h, mock_srv = self._started_handler()
+        opts = {"PASS": 1, "FAIL": 2}
+        h.show_prompt("msg", opts)
+        assert mock_srv.prompt_options == opts
+
+    def test_show_prompt_sets_ready_true(self):
+        h, mock_srv = self._started_handler()
+        h.show_prompt("msg", {})
+        assert mock_srv.prompt_ready is True
+
+    def test_show_prompt_noop_when_server_is_none(self):
+        h = TwoWayTalkHandler(port=0)
+        # Must not raise
+        h.show_prompt("msg", {"PASS": 1})
+
+    def test_update_prompt_delegates_to_show_prompt(self):
+        h, mock_srv = self._started_handler()
+        h.update_prompt("Updated", {"PASS": 1})
+        assert mock_srv.prompt_text == "Updated"
+        assert mock_srv.prompt_ready is True
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — wait_for_browser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerWaitForBrowser:
+    """Positive + edge: wait_for_browser reflects browser_ready_event state."""
+
+    def test_returns_true_when_event_already_set(self):
+        h = TwoWayTalkHandler(port=0)
+        h._browser_ready_event.set()
+        assert h.wait_for_browser(timeout=1.0) is True
+
+    def test_returns_false_on_timeout(self):
+        h = TwoWayTalkHandler(port=0)
+        result = h.wait_for_browser(timeout=0.05)
+        assert result is False
+
+    def test_returns_true_when_event_set_concurrently(self):
+        h = TwoWayTalkHandler(port=0)
+
+        def _set_later():
+            time.sleep(0.05)
+            h._browser_ready_event.set()
+
+        threading.Thread(target=_set_later, daemon=True).start()
+        assert h.wait_for_browser(timeout=2.0) is True
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — wait_for_user_response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerWaitForUserResponse:
+    """Positive + edge: async polling of response queue."""
+
+    @pytest.mark.asyncio
+    async def test_returns_queued_value_immediately(self):
+        h = TwoWayTalkHandler(port=0)
+        h._response_queue.put_nowait(1)
+        result = await h.wait_for_user_response(timeout=1.0)
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_timeout(self):
+        h = TwoWayTalkHandler(port=0)
+        result = await h.wait_for_user_response(timeout=0.05)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_value_queued_after_start(self):
+        h = TwoWayTalkHandler(port=0)
+
+        async def _put_later():
+            await asyncio.sleep(0.05)
+            h._response_queue.put_nowait(2)
+
+        asyncio.create_task(_put_later())
+        result = await h.wait_for_user_response(timeout=2.0)
+        assert result == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_as_valid_response(self):
+        h = TwoWayTalkHandler(port=0)
+        h._response_queue.put_nowait(0)
+        result = await h.wait_for_user_response(timeout=1.0)
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerStop:
+    """Positive + edge: stop shuts down server and clears global state."""
+
+    def test_stop_calls_server_shutdown(self):
+        h = TwoWayTalkHandler(port=0)
+        mock_srv = Mock()
+        h._server = mock_srv
+        set_active_handler(h)
+
+        h.stop()
+
+        mock_srv.shutdown.assert_called_once()
+
+    def test_stop_clears_server_reference(self):
+        h = TwoWayTalkHandler(port=0)
+        h._server = Mock()
+        h.stop()
+        assert h._server is None
+
+    def test_stop_clears_active_handler(self):
+        h = TwoWayTalkHandler(port=0)
+        h._server = Mock()
+        set_active_handler(h)
+        h.stop()
+        assert get_active_handler() is None
+
+    def test_stop_clears_module_level_active_server(self):
+        h = TwoWayTalkHandler(port=0)
+        mock_srv = Mock()
+        h._server = mock_srv
+        _module._active_server = mock_srv
+        h.stop()
+        assert _module._active_server is None
+
+    def test_stop_is_noop_when_server_is_none(self):
+        h = TwoWayTalkHandler(port=0)
+        h.stop()  # must not raise
+        assert h._server is None
+
+    def test_stop_clears_server_even_when_shutdown_raises(self):
+        h = TwoWayTalkHandler(port=0)
+        mock_srv = Mock()
+        mock_srv.shutdown.side_effect = Exception("already dead")
+        h._server = mock_srv
+        h.stop()  # must not propagate
+        assert h._server is None
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHandler — start (backward-compat alias)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHandlerStartAlias:
+    """Positive: start() calls start_waiting() then show_prompt()."""
+
+    def test_start_calls_start_waiting_and_show_prompt(self):
+        h = TwoWayTalkHandler(port=0)
+        with patch.object(h, "start_waiting") as mock_wait:
+            with patch.object(h, "show_prompt") as mock_show:
+                h.start("Verify", {"PASS": 1})
+        mock_wait.assert_called_once()
+        mock_show.assert_called_once_with("Verify", {"PASS": 1})
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModuleLevelHelpers:
+    """Positive + negative: get/set active handler and show_prompt_on_active_server."""
+
+    def test_set_and_get_active_handler(self):
+        h = TwoWayTalkHandler(port=0)
+        set_active_handler(h)
+        assert get_active_handler() is h
+        set_active_handler(None)  # cleanup
+
+    def test_set_active_handler_to_none(self):
+        set_active_handler(None)
+        assert get_active_handler() is None
+
+    def test_show_prompt_on_active_server_returns_true_when_server_exists(self):
+        mock_srv = Mock()
+        _module._active_server = mock_srv
+        result = show_prompt_on_active_server("Hello", {"PASS": 1})
+        assert result is True
+        assert mock_srv.prompt_text == "Hello"
+        assert mock_srv.prompt_options == {"PASS": 1}
+        assert mock_srv.prompt_ready is True
+        _module._active_server = None  # cleanup
+
+    def test_show_prompt_on_active_server_returns_false_when_no_server(self):
+        _module._active_server = None
+        result = show_prompt_on_active_server("Hello", {})
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHTTPHandler — routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTwoWayTalkHTTPHandlerRouting:
+    """Positive: GET/POST routes dispatch to correct methods."""
+
+    def test_do_get_root_calls_serve_page(self):
+        h = _make_http_handler(path="/")
+        with patch.object(h, "_serve_page") as mock_fn:
+            h.do_GET()
+        mock_fn.assert_called_once()
+
+    def test_do_get_with_query_string_calls_serve_page(self):
+        h = _make_http_handler(path="/?nocache=123")
+        with patch.object(h, "_serve_page") as mock_fn:
+            h.do_GET()
+        mock_fn.assert_called_once()
+
+    def test_do_get_prompt_ready_calls_serve_prompt_ready(self):
+        h = _make_http_handler(path="/prompt_ready")
+        with patch.object(h, "_serve_prompt_ready") as mock_fn:
+            h.do_GET()
+        mock_fn.assert_called_once()
+
+    def test_do_get_unknown_path_sends_404(self):
+        h = _make_http_handler(path="/not/found")
+        h.do_GET()
+        assert h._error_code == 404
+
+    def test_do_post_submit_response_calls_handle_response(self):
+        h = _make_http_handler(path="/submit_response", method="POST")
+        with patch.object(h, "_handle_response") as mock_fn:
+            h.do_POST()
+        mock_fn.assert_called_once()
+
+    def test_do_post_browser_ready_calls_handle_browser_ready(self):
+        h = _make_http_handler(path="/browser_ready", method="POST")
+        with patch.object(h, "_handle_browser_ready") as mock_fn:
+            h.do_POST()
+        mock_fn.assert_called_once()
+
+    def test_do_post_unknown_path_sends_404(self):
+        h = _make_http_handler(path="/unknown", method="POST")
+        h.do_POST()
+        assert h._error_code == 404
+
+    def test_do_options_returns_200(self):
+        h = _make_http_handler(method="OPTIONS")
+        h.do_OPTIONS()
+        assert h._response_code == 200
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHTTPHandler — /prompt_ready JSON endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestServePromptReady:
+    """Positive + edge: /prompt_ready returns correct JSON payload."""
+
+    def test_returns_ready_false_when_not_ready(self):
+        h = _make_http_handler(path="/prompt_ready", server_attrs={"prompt_ready": False})
+        h._serve_prompt_ready()
+        assert h._response_code == 200
+        body = json.loads(h.wfile.getvalue())
+        assert body == {"ready": False}
+
+    def test_returns_ready_true_with_text_and_options_when_ready(self):
+        h = _make_http_handler(
+            path="/prompt_ready",
+            server_attrs={
+                "prompt_ready": True,
+                "prompt_text": "Verify audio",
+                "prompt_options": {"PASS": 1, "FAIL": 2},
+            },
+        )
+        h._serve_prompt_ready()
+        body = json.loads(h.wfile.getvalue())
+        assert body["ready"] is True
+        assert body["prompt_text"] == "Verify audio"
+        assert body["options"] == {"PASS": 1, "FAIL": 2}
+
+    def test_content_type_header_is_json(self):
+        h = _make_http_handler(path="/prompt_ready", server_attrs={"prompt_ready": False})
+        h._serve_prompt_ready()
+        assert h._headers_sent.get("Content-Type") == "application/json"
+
+    def test_options_not_included_when_not_ready(self):
+        h = _make_http_handler(path="/prompt_ready", server_attrs={"prompt_ready": False})
+        h._serve_prompt_ready()
+        body = json.loads(h.wfile.getvalue())
+        assert "options" not in body
+        assert "prompt_text" not in body
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHTTPHandler — /submit_response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHandleResponse:
+    """Positive + negative: /submit_response validates input and enqueues value."""
+
+    def _make(self, body: bytes, headers: dict = None, response_queue=None):
+        content_length = str(len(body))
+        hdrs = {"Content-Length": content_length}
+        if headers:
+            hdrs.update(headers)
+        srv_attrs = {}
+        if response_queue is not None:
+            srv_attrs["response_queue"] = response_queue
+        return _make_http_handler(
+            path="/submit_response",
+            method="POST",
+            headers=hdrs,
+            body=body,
+            server_attrs=srv_attrs,
+        )
+
+    def test_valid_response_enqueued_and_200_returned(self):
+        resp_q = queue.Queue()
+        body = json.dumps({"response": 1}).encode()
+        h = self._make(body, response_queue=resp_q)
+        h._handle_response()
+        assert h._response_code == 200
+        assert resp_q.get_nowait() == 1
+
+    def test_response_body_is_success_json(self):
+        resp_q = queue.Queue()
+        body = json.dumps({"response": 2}).encode()
+        h = self._make(body, response_queue=resp_q)
+        h._handle_response()
+        output = json.loads(h.wfile.getvalue())
+        assert output == {"status": "success"}
+
+    def test_missing_content_length_returns_400(self):
+        h = _make_http_handler(
+            path="/submit_response",
+            method="POST",
+            headers={},
+            body=b"",
+        )
+        h._handle_response()
+        assert h._error_code == 400
+
+    def test_missing_response_key_returns_500(self):
+        body = json.dumps({"other": 99}).encode()
+        h = self._make(body, response_queue=queue.Queue())
+        h._handle_response()
+        assert h._response_code == 500
+
+    def test_non_integer_response_value_returns_500(self):
+        body = json.dumps({"response": "not-a-number"}).encode()
+        h = self._make(body, response_queue=queue.Queue())
+        h._handle_response()
+        assert h._response_code == 500
+
+    def test_no_response_queue_returns_500(self):
+        body = json.dumps({"response": 1}).encode()
+        h = _make_http_handler(
+            path="/submit_response",
+            method="POST",
+            headers={"Content-Length": str(len(body))},
+            body=body,
+            server_attrs={},
+        )
+        h.server.response_queue = None
+        h._handle_response()
+        assert h._error_code == 500
+
+
+# ---------------------------------------------------------------------------
+# TwoWayTalkHTTPHandler — /browser_ready
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHandleBrowserReady:
+    """Positive + edge: /browser_ready sets the threading.Event."""
+
+    def test_sets_browser_ready_event(self):
+        event = threading.Event()
+        h = _make_http_handler(
+            path="/browser_ready",
+            method="POST",
+            server_attrs={"browser_ready_event": event},
+        )
+        h._handle_browser_ready()
+        assert event.is_set()
+
+    def test_returns_200_ok(self):
+        event = threading.Event()
+        h = _make_http_handler(
+            path="/browser_ready",
+            method="POST",
+            server_attrs={"browser_ready_event": event},
+        )
+        h._handle_browser_ready()
+        assert h._response_code == 200
+
+    def test_response_body_is_ok_json(self):
+        event = threading.Event()
+        h = _make_http_handler(
+            path="/browser_ready",
+            method="POST",
+            server_attrs={"browser_ready_event": event},
+        )
+        h._handle_browser_ready()
+        output = json.loads(h.wfile.getvalue())
+        assert output == {"status": "ok"}
+
+    def test_no_event_on_server_does_not_raise(self):
+        h = _make_http_handler(path="/browser_ready", method="POST")
+        h.server.browser_ready_event = None
+        h._handle_browser_ready()  # must not raise
+        assert h._response_code == 200

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -397,23 +397,27 @@ def _make_two_way_talk_prompt(**kwargs):
 class TestHandleTwoWayTalkPrompt:
     """Tests for _handle_two_way_talk_prompt dispatched via handle_prompt."""
 
-    @pytest.mark.asyncio
-    async def test_uses_active_handler_when_available(self):
-        """When an active handler exists, it should be used directly."""
-        prompt = _make_two_way_talk_prompt()
+    def _make_handler(self, response=1):
         mock_handler = AsyncMock()
-        mock_handler.wait_for_user_response = AsyncMock(return_value=1)
+        mock_handler.wait_for_user_response = AsyncMock(return_value=response)
         mock_handler.show_prompt = Mock()
         mock_handler.stop = Mock()
+        return mock_handler
+
+    @pytest.mark.asyncio
+    async def test_uses_injected_handler(self):
+        """When a handler is injected, it should be used directly."""
+        prompt = _make_two_way_talk_prompt()
+        mock_handler = self._make_handler(response=1)
 
         with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock):
-            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
-                with patch("click.echo"):
-                    await prompt_manager.handle_prompt(
-                        socket=AsyncMock(),
-                        request=prompt,
-                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
-                    )
+            with patch("click.echo"):
+                await prompt_manager.handle_prompt(
+                    socket=AsyncMock(),
+                    request=prompt,
+                    message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    two_way_talk_handler=mock_handler,
+                )
 
         mock_handler.show_prompt.assert_called_once_with(prompt_text=prompt.prompt, prompt_options=prompt.options)
 
@@ -421,19 +425,16 @@ class TestHandleTwoWayTalkPrompt:
     async def test_sends_response_for_pass_selection(self):
         """Selected PASS option is forwarded to backend."""
         prompt = _make_two_way_talk_prompt()
-        mock_handler = AsyncMock()
-        mock_handler.wait_for_user_response = AsyncMock(return_value=1)  # PASS = 1
-        mock_handler.show_prompt = Mock()
-        mock_handler.stop = Mock()
+        mock_handler = self._make_handler(response=1)  # PASS = 1
 
         with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
-            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
-                with patch("click.echo"):
-                    await prompt_manager.handle_prompt(
-                        socket=AsyncMock(),
-                        request=prompt,
-                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
-                    )
+            with patch("click.echo"):
+                await prompt_manager.handle_prompt(
+                    socket=AsyncMock(),
+                    request=prompt,
+                    message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    two_way_talk_handler=mock_handler,
+                )
 
         mock_send.assert_called_once()
         assert mock_send.call_args[1]["response"] == 1
@@ -442,19 +443,16 @@ class TestHandleTwoWayTalkPrompt:
     async def test_stop_called_after_response(self):
         """handler.stop() must always be called after wait_for_user_response."""
         prompt = _make_two_way_talk_prompt()
-        mock_handler = AsyncMock()
-        mock_handler.wait_for_user_response = AsyncMock(return_value=2)  # FAIL = 2
-        mock_handler.show_prompt = Mock()
-        mock_handler.stop = Mock()
+        mock_handler = self._make_handler(response=2)  # FAIL = 2
 
         with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock):
-            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
-                with patch("click.echo"):
-                    await prompt_manager.handle_prompt(
-                        socket=AsyncMock(),
-                        request=prompt,
-                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
-                    )
+            with patch("click.echo"):
+                await prompt_manager.handle_prompt(
+                    socket=AsyncMock(),
+                    request=prompt,
+                    message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    two_way_talk_handler=mock_handler,
+                )
 
         mock_handler.stop.assert_called_once()
 
@@ -462,26 +460,23 @@ class TestHandleTwoWayTalkPrompt:
     async def test_stop_called_even_on_timeout(self):
         """handler.stop() must be called even when wait_for_user_response returns None."""
         prompt = _make_two_way_talk_prompt()
-        mock_handler = AsyncMock()
-        mock_handler.wait_for_user_response = AsyncMock(return_value=None)
-        mock_handler.show_prompt = Mock()
-        mock_handler.stop = Mock()
+        mock_handler = self._make_handler(response=None)
 
         with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
-            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
-                with patch("click.echo"):
-                    await prompt_manager.handle_prompt(
-                        socket=AsyncMock(),
-                        request=prompt,
-                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
-                    )
+            with patch("click.echo"):
+                await prompt_manager.handle_prompt(
+                    socket=AsyncMock(),
+                    request=prompt,
+                    message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    two_way_talk_handler=mock_handler,
+                )
 
         mock_handler.stop.assert_called_once()
         mock_send.assert_not_called()  # no response sent on timeout
 
     @pytest.mark.asyncio
-    async def test_fallback_handler_created_when_active_handler_is_none(self):
-        """When no active handler, a fallback TwoWayTalkHandler is created with start_server_only."""
+    async def test_fallback_handler_created_when_no_handler_injected(self):
+        """When no handler is injected, a fallback TwoWayTalkHandler is created with start_server_only."""
         prompt = _make_two_way_talk_prompt()
         mock_fallback = AsyncMock()
         mock_fallback.wait_for_user_response = AsyncMock(return_value=1)
@@ -490,16 +485,14 @@ class TestHandleTwoWayTalkPrompt:
         mock_fallback.start_server_only = Mock()
 
         with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock):
-            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=None):
-                with patch(
-                    "th_cli.test_run.camera.two_way_talk_handler.TwoWayTalkHandler", return_value=mock_fallback
-                ) as mock_cls:
-                    with patch("click.echo"):
-                        await prompt_manager.handle_prompt(
-                            socket=AsyncMock(),
-                            request=prompt,
-                            message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
-                        )
+            with patch("th_cli.test_run.prompt_manager.TwoWayTalkHandler", return_value=mock_fallback) as mock_cls:
+                with patch("click.echo"):
+                    await prompt_manager.handle_prompt(
+                        socket=AsyncMock(),
+                        request=prompt,
+                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                        two_way_talk_handler=None,
+                    )
 
         mock_cls.assert_called_once_with(port=8999)
         mock_fallback.start_server_only.assert_called_once()
@@ -508,19 +501,16 @@ class TestHandleTwoWayTalkPrompt:
     async def test_dispatched_via_isinstance_when_no_message_type(self):
         """Dispatch works via isinstance check when message_type is not provided."""
         prompt = _make_two_way_talk_prompt()
-        mock_handler = AsyncMock()
-        mock_handler.wait_for_user_response = AsyncMock(return_value=1)
-        mock_handler.show_prompt = Mock()
-        mock_handler.stop = Mock()
+        mock_handler = self._make_handler(response=1)
 
         with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
-            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
-                with patch("click.echo"):
-                    await prompt_manager.handle_prompt(
-                        socket=AsyncMock(),
-                        request=prompt,
-                        message_type=None,
-                    )
+            with patch("click.echo"):
+                await prompt_manager.handle_prompt(
+                    socket=AsyncMock(),
+                    request=prompt,
+                    message_type=None,
+                    two_way_talk_handler=mock_handler,
+                )
 
         mock_send.assert_called_once()
 

--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -30,6 +30,7 @@ from th_cli.test_run.socket_schemas import (
     PromptRequest,
     PushAVStreamVerificationRequest,
     TextInputPromptRequest,
+    TwoWayTalkVerificationRequest,
     UserResponseStatusEnum,
 )
 
@@ -373,6 +374,155 @@ class TestValidFileUpload:
 
         mock_send.assert_called_once()
         assert mock_send.call_args[1]["response"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _handle_two_way_talk_prompt (via handle_prompt dispatch)
+# ---------------------------------------------------------------------------
+
+
+def _make_two_way_talk_prompt(**kwargs):
+    """Build a minimal TwoWayTalkVerificationRequest."""
+    defaults = dict(
+        prompt="Verify if two way talk is working",
+        options={"PASS": 1, "FAIL": 2},
+        timeout=10,
+        message_id=99,
+    )
+    defaults.update(kwargs)
+    return TwoWayTalkVerificationRequest(**defaults)
+
+
+@pytest.mark.unit
+class TestHandleTwoWayTalkPrompt:
+    """Tests for _handle_two_way_talk_prompt dispatched via handle_prompt."""
+
+    @pytest.mark.asyncio
+    async def test_uses_active_handler_when_available(self):
+        """When an active handler exists, it should be used directly."""
+        prompt = _make_two_way_talk_prompt()
+        mock_handler = AsyncMock()
+        mock_handler.wait_for_user_response = AsyncMock(return_value=1)
+        mock_handler.show_prompt = Mock()
+        mock_handler.stop = Mock()
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock):
+            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
+                with patch("click.echo"):
+                    await prompt_manager.handle_prompt(
+                        socket=AsyncMock(),
+                        request=prompt,
+                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    )
+
+        mock_handler.show_prompt.assert_called_once_with(prompt_text=prompt.prompt, prompt_options=prompt.options)
+
+    @pytest.mark.asyncio
+    async def test_sends_response_for_pass_selection(self):
+        """Selected PASS option is forwarded to backend."""
+        prompt = _make_two_way_talk_prompt()
+        mock_handler = AsyncMock()
+        mock_handler.wait_for_user_response = AsyncMock(return_value=1)  # PASS = 1
+        mock_handler.show_prompt = Mock()
+        mock_handler.stop = Mock()
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
+            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
+                with patch("click.echo"):
+                    await prompt_manager.handle_prompt(
+                        socket=AsyncMock(),
+                        request=prompt,
+                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    )
+
+        mock_send.assert_called_once()
+        assert mock_send.call_args[1]["response"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_called_after_response(self):
+        """handler.stop() must always be called after wait_for_user_response."""
+        prompt = _make_two_way_talk_prompt()
+        mock_handler = AsyncMock()
+        mock_handler.wait_for_user_response = AsyncMock(return_value=2)  # FAIL = 2
+        mock_handler.show_prompt = Mock()
+        mock_handler.stop = Mock()
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock):
+            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
+                with patch("click.echo"):
+                    await prompt_manager.handle_prompt(
+                        socket=AsyncMock(),
+                        request=prompt,
+                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    )
+
+        mock_handler.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_called_even_on_timeout(self):
+        """handler.stop() must be called even when wait_for_user_response returns None."""
+        prompt = _make_two_way_talk_prompt()
+        mock_handler = AsyncMock()
+        mock_handler.wait_for_user_response = AsyncMock(return_value=None)
+        mock_handler.show_prompt = Mock()
+        mock_handler.stop = Mock()
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
+            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
+                with patch("click.echo"):
+                    await prompt_manager.handle_prompt(
+                        socket=AsyncMock(),
+                        request=prompt,
+                        message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                    )
+
+        mock_handler.stop.assert_called_once()
+        mock_send.assert_not_called()  # no response sent on timeout
+
+    @pytest.mark.asyncio
+    async def test_fallback_handler_created_when_active_handler_is_none(self):
+        """When no active handler, a fallback TwoWayTalkHandler is created with start_server_only."""
+        prompt = _make_two_way_talk_prompt()
+        mock_fallback = AsyncMock()
+        mock_fallback.wait_for_user_response = AsyncMock(return_value=1)
+        mock_fallback.show_prompt = Mock()
+        mock_fallback.stop = Mock()
+        mock_fallback.start_server_only = Mock()
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock):
+            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=None):
+                with patch(
+                    "th_cli.test_run.camera.two_way_talk_handler.TwoWayTalkHandler", return_value=mock_fallback
+                ) as mock_cls:
+                    with patch("click.echo"):
+                        await prompt_manager.handle_prompt(
+                            socket=AsyncMock(),
+                            request=prompt,
+                            message_type=MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST,
+                        )
+
+        mock_cls.assert_called_once_with(port=8999)
+        mock_fallback.start_server_only.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatched_via_isinstance_when_no_message_type(self):
+        """Dispatch works via isinstance check when message_type is not provided."""
+        prompt = _make_two_way_talk_prompt()
+        mock_handler = AsyncMock()
+        mock_handler.wait_for_user_response = AsyncMock(return_value=1)
+        mock_handler.show_prompt = Mock()
+        mock_handler.stop = Mock()
+
+        with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
+            with patch("th_cli.test_run.camera.two_way_talk_handler.get_active_handler", return_value=mock_handler):
+                with patch("click.echo"):
+                    await prompt_manager.handle_prompt(
+                        socket=AsyncMock(),
+                        request=prompt,
+                        message_type=None,
+                    )
+
+        mock_send.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_invalid_extension_retries_then_skip(self):

--- a/tests/test_run/test_websocket_socket.py
+++ b/tests/test_run/test_websocket_socket.py
@@ -209,7 +209,7 @@ class TestLogTestStepUpdate:
 
 
 # ---------------------------------------------------------------------------
-# __log_test_case_update — WebRTC detection and error cleanup
+# __log_test_case_update — error cleanup
 # ---------------------------------------------------------------------------
 
 
@@ -227,51 +227,6 @@ class TestLogTestCaseUpdate:
             errors=errors,
         )
 
-    def test_webrtc_warning_shown_for_webrtc_error_text(self):
-        case = _make_case()
-        suite = _make_suite(cases=[case])
-        s = _make_socket(suites=[suite])
-
-        with patch("click.echo") as mock_echo:
-            self._call(s, self._update(errors=["error: webrtc browser failed"]))
-
-        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
-        assert "TWO-WAY TALK" in echoed
-
-    def test_webrtc_warning_shown_for_known_public_id(self):
-        case = _make_case(public_id="TC_WEBRTC_1_6")
-        suite = _make_suite(cases=[case])
-        s = _make_socket(suites=[suite])
-
-        with patch("click.echo") as mock_echo:
-            self._call(s, self._update(errors=None))
-
-        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
-        assert "TWO-WAY TALK" in echoed
-
-    def test_webrtc_warning_shown_when_step_errors_contain_indicator(self):
-        case = _make_case()
-        suite = _make_suite(cases=[case])
-        s = _make_socket(suites=[suite])
-        s.test_case_step_errors[(0, 0)] = ["BrowserPeerConnection refused"]
-
-        with patch("click.echo") as mock_echo:
-            self._call(s, self._update(errors=None))
-
-        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
-        assert "TWO-WAY TALK" in echoed
-
-    def test_no_webrtc_warning_for_non_webrtc_failure(self):
-        case = _make_case(public_id="TC_CLUSTER_1_1")
-        suite = _make_suite(cases=[case])
-        s = _make_socket(suites=[suite])
-
-        with patch("click.echo") as mock_echo:
-            self._call(s, self._update(errors=["attribute read failed"]))
-
-        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
-        assert "TWO-WAY TALK" not in echoed
-
     def test_step_errors_cleaned_up_after_case_update(self):
         case = _make_case()
         suite = _make_suite(cases=[case])
@@ -282,7 +237,18 @@ class TestLogTestCaseUpdate:
 
         assert (0, 0) not in s.test_case_step_errors
 
-    def test_passing_case_does_not_show_webrtc_warning(self):
+    def test_failed_case_echoes_state(self):
+        case = _make_case()
+        suite = _make_suite(cases=[case])
+        s = _make_socket(suites=[suite])
+
+        with patch("click.echo") as mock_echo:
+            self._call(s, self._update(state="failed"))
+
+        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
+        assert "failed" in echoed.lower()
+
+    def test_passed_case_echoes_state(self):
         case = _make_case()
         suite = _make_suite(cases=[case])
         s = _make_socket(suites=[suite])
@@ -291,26 +257,29 @@ class TestLogTestCaseUpdate:
             self._call(s, self._update(state="passed"))
 
         echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
-        assert "TWO-WAY TALK" not in echoed
+        assert "passed" in echoed.lower()
 
-    def test_all_webrtc_indicators_trigger_warning(self):
-        indicators = [
-            "browserpeerconnection failed",
-            "webrtc setup error",
-            "browser peer not available",
-            "ws://backend/api/v1/ws/webrtc timeout",
-            "create_browser_peer called",
-        ]
-        for indicator in indicators:
-            case = _make_case()
-            suite = _make_suite(cases=[case])
-            s = _make_socket(suites=[suite])
+    def test_browser_peer_warning_shown_for_peer_not_found(self):
+        case = _make_case(public_id="TC_WEBRTC_1_6")
+        suite = _make_suite(cases=[case])
+        s = _make_socket(suites=[suite])
 
-            with patch("click.echo") as mock_echo:
-                self._call(s, self._update(errors=[indicator]))
+        with patch("click.echo") as mock_echo:
+            self._call(s, self._update(errors=["Peer not found"]))
 
-            echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
-            assert "TWO-WAY TALK" in echoed, f"Expected WebRTC warning for: {indicator!r}"
+        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
+        assert "BROWSER TAB REQUIRED" in echoed
+
+    def test_browser_peer_warning_not_shown_for_unrelated_failure(self):
+        case = _make_case(public_id="TC_CLUSTER_1_1")
+        suite = _make_suite(cases=[case])
+        s = _make_socket(suites=[suite])
+
+        with patch("click.echo") as mock_echo:
+            self._call(s, self._update(errors=["attribute read failed"]))
+
+        echoed = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
+        assert "BROWSER TAB REQUIRED" not in echoed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -15,6 +15,8 @@
 #
 """Tests for the run_tests command."""
 
+import re
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -23,7 +25,14 @@ from click.testing import CliRunner
 
 from th_cli.api_lib_autogen import models as api_models
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
-from th_cli.commands.run_tests import _parse_extra_args, run_tests
+from th_cli.commands.run_tests import (
+    TWO_WAY_TALK_TEST_IDS,
+    _contains_webrtc_two_way_talk,
+    _dict_contains_key,
+    _parse_extra_args,
+    _print_webrtc_banner_and_wait,
+    run_tests,
+)
 from th_cli.exceptions import ConfigurationError
 
 
@@ -1062,3 +1071,186 @@ class TestRunTestsWithExtraArgs:
         assert result.exit_code == 0
         # Verify deepcopy was called to ensure isolation
         mock_deepcopy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _dict_contains_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDictContainsKey:
+    """Tests for _dict_contains_key — recursive key search."""
+
+    def test_key_at_top_level(self):
+        assert _dict_contains_key({"TC_WEBRTC_1_6": 1}, "TC_WEBRTC_1_6") is True
+
+    def test_key_nested_one_level(self):
+        d = {"suite": {"TC_WEBRTC_1_6": 1}}
+        assert _dict_contains_key(d, "TC_WEBRTC_1_6") is True
+
+    def test_key_nested_two_levels(self):
+        d = {"collection": {"suite": {"TC_WEBRTC_1_6": 1}}}
+        assert _dict_contains_key(d, "TC_WEBRTC_1_6") is True
+
+    def test_key_absent(self):
+        assert _dict_contains_key({"TC_OTHER": 1}, "TC_WEBRTC_1_6") is False
+
+    def test_empty_dict(self):
+        assert _dict_contains_key({}, "TC_WEBRTC_1_6") is False
+
+    def test_non_dict_input_returns_false(self):
+        assert _dict_contains_key(["TC_WEBRTC_1_6"], "TC_WEBRTC_1_6") is False
+
+    def test_none_input_returns_false(self):
+        assert _dict_contains_key(None, "TC_WEBRTC_1_6") is False
+
+    def test_value_equal_to_target_but_not_key(self):
+        # Value matches target but it should only check keys
+        assert _dict_contains_key({"other": "TC_WEBRTC_1_6"}, "TC_WEBRTC_1_6") is False
+
+
+# ---------------------------------------------------------------------------
+# _contains_webrtc_two_way_talk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestContainsWebrtcTwoWayTalk:
+    """Tests for _contains_webrtc_two_way_talk and TWO_WAY_TALK_TEST_IDS constant."""
+
+    def test_constant_is_non_empty(self):
+        assert len(TWO_WAY_TALK_TEST_IDS) > 0
+
+    def test_constant_contains_tc_webrtc_1_6(self):
+        assert "TC_WEBRTC_1_6" in TWO_WAY_TALK_TEST_IDS
+
+    def test_returns_true_when_tc_webrtc_1_6_present(self):
+        selected = {"SDK Python Tests": {"Python Testing Suite": {"TC_WEBRTC_1_6": 1}}}
+        assert _contains_webrtc_two_way_talk(selected) is True
+
+    def test_returns_false_when_only_other_tests_present(self):
+        selected = {"SDK Python Tests": {"Python Testing Suite": {"TC_ACE_1_3": 1}}}
+        assert _contains_webrtc_two_way_talk(selected) is False
+
+    def test_returns_false_for_empty_selection(self):
+        assert _contains_webrtc_two_way_talk({}) is False
+
+    def test_returns_true_when_mixed_tests_include_webrtc(self):
+        selected = {
+            "SDK Python Tests": {
+                "Python Testing Suite": {
+                    "TC_ACE_1_3": 1,
+                    "TC_WEBRTC_1_6": 1,
+                }
+            }
+        }
+        assert _contains_webrtc_two_way_talk(selected) is True
+
+    def test_partial_name_does_not_match(self):
+        selected = {"SDK Python Tests": {"Suite": {"TC_WEBRTC_1_6_EXTRA": 1}}}
+        assert _contains_webrtc_two_way_talk(selected) is False
+
+    def test_returns_true_for_any_id_in_constant(self):
+        """Every ID in TWO_WAY_TALK_TEST_IDS must trigger True individually."""
+        for tc_id in TWO_WAY_TALK_TEST_IDS:
+            selected = {"Suite": {tc_id: 1}}
+            assert _contains_webrtc_two_way_talk(selected) is True, f"{tc_id} should trigger two-way talk"
+
+
+# ---------------------------------------------------------------------------
+# _print_webrtc_banner_and_wait
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPrintWebrtcBannerAndWait:
+    """Tests for _print_webrtc_banner_and_wait — banner output and browser wait."""
+
+    def _make_handler(self, wait_result: bool):
+        handler = Mock()
+        handler.wait_for_browser = Mock(return_value=wait_result)
+        return handler
+
+    def _patches(self, resolved="127.0.0.1", wait_result=True):
+        stack = ExitStack()
+        stack.enter_context(patch("socket.gethostbyname", return_value=resolved))
+        stack.enter_context(patch("th_cli.test_run.camera.two_way_talk_handler._get_local_ip", return_value="10.0.0.5"))
+        mock_loop = stack.enter_context(patch("asyncio.get_event_loop"))
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value=wait_result)
+        return stack
+
+    @pytest.mark.asyncio
+    async def test_wait_for_browser_called_on_handler(self):
+        """handler.wait_for_browser must be passed to run_in_executor."""
+        handler = self._make_handler(True)
+        with patch("click.echo"):
+            with self._patches():
+                await _print_webrtc_banner_and_wait("localhost", handler)
+
+        # run_in_executor was called with handler.wait_for_browser
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=True)
+            pass  # already verified above implicitly
+
+    @pytest.mark.asyncio
+    async def test_prints_connected_message_when_browser_connects(self):
+        handler = self._make_handler(True)
+        with patch("click.echo") as mock_echo:
+            with self._patches(wait_result=True):
+                await _print_webrtc_banner_and_wait("localhost", handler)
+
+        raw = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
+        output = re.sub(r"\x1b\[[0-9;]*m", "", raw)
+        assert "Browser connected" in output
+
+    @pytest.mark.asyncio
+    async def test_prints_not_detected_message_on_timeout(self):
+        handler = self._make_handler(False)
+        with patch("click.echo") as mock_echo:
+            with self._patches(wait_result=False):
+                await _print_webrtc_banner_and_wait("localhost", handler)
+
+        raw = " ".join(str(c) for call in mock_echo.call_args_list for c in call[0])
+        output = re.sub(r"\x1b\[[0-9;]*m", "", raw).lower()
+        assert "not detected" in output or "proceeding anyway" in output
+
+    @pytest.mark.asyncio
+    async def test_loopback_hostname_triggers_local_ip_lookup(self):
+        """When hostname resolves to loopback, URL must use the LAN IP from _get_local_ip."""
+        handler = self._make_handler(True)
+        lan_ip = "192.168.1.50"
+        captured_echo_args = []
+
+        def capture_echo(arg=""):
+            captured_echo_args.append(str(arg))
+
+        with patch("click.echo", side_effect=capture_echo):
+            with patch("socket.gethostbyname", return_value="127.0.0.1"):
+                with patch(
+                    "th_cli.test_run.camera.two_way_talk_handler._get_local_ip",
+                    return_value=lan_ip,
+                ):
+                    with patch("asyncio.get_event_loop") as mock_loop:
+                        mock_loop.return_value.run_in_executor = AsyncMock(return_value=True)
+                        await _print_webrtc_banner_and_wait("localhost", handler)
+
+        # The URL echoed must contain the LAN IP, not loopback
+        all_output = " ".join(re.sub(r"\x1b\[[0-9;]*m", "", s) for s in captured_echo_args)
+        assert lan_ip in all_output
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_hostname_skips_local_ip_lookup(self):
+        """When hostname resolves to a LAN IP, _get_local_ip() must NOT be called."""
+        handler = self._make_handler(True)
+        with patch("click.echo"):
+            with patch("socket.gethostbyname", return_value="192.168.1.100"):
+                with patch(
+                    "th_cli.test_run.camera.two_way_talk_handler._get_local_ip",
+                    return_value="192.168.1.50",
+                ) as mock_local_ip:
+                    with patch("asyncio.get_event_loop") as mock_loop:
+                        mock_loop.return_value.run_in_executor = AsyncMock(return_value=True)
+                        await _print_webrtc_banner_and_wait("192.168.1.100", handler)
+
+        mock_local_ip.assert_not_called()

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -35,6 +35,7 @@ from th_cli.colorize import (
     italic,
     set_colors_enabled,
 )
+from th_cli.config import config as th_config
 from th_cli.exceptions import CLIError, handle_api_error
 from th_cli.test_run.websocket import TestRunSocket
 from th_cli.utils import build_test_selection, convert_nested_to_dict, load_json_config, merge_configs, read_pics_config
@@ -133,6 +134,7 @@ async def run_tests(
         pics_config_folder = str(pics_path)
 
     client = None
+    _webrtc_handler = None
     try:
         client = get_client()
         async_apis = AsyncApis(client)
@@ -186,6 +188,14 @@ async def run_tests(
             pics=pics,
             project_id=project_id,
         )
+        if _contains_webrtc_two_way_talk(selected_tests_dict):
+            from th_cli.test_run.camera.two_way_talk_handler import TwoWayTalkHandler
+
+            _webrtc_handler = TwoWayTalkHandler(port=8999)
+            _webrtc_handler.start_waiting()
+            await _print_webrtc_banner_and_wait(th_config.hostname, _webrtc_handler)
+        else:
+            _webrtc_handler = None
         socket = TestRunSocket(new_test_run, test_run_config)
         socket_task = asyncio.create_task(socket.connect_websocket())
         new_test_run = await _start_test_run(async_apis, new_test_run)
@@ -199,6 +209,8 @@ async def run_tests(
     finally:
         if client:
             await client.aclose()
+        if _webrtc_handler:
+            _webrtc_handler.stop()
 
 
 async def _get_project_config(async_apis: AsyncApis, project_id: int | None = None) -> dict[str, Any]:
@@ -228,6 +240,59 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
             click.echo(colorize_key_value("Warning:", msg))
 
     return await projects_api.default_config_api_v1_projects_default_config_get()
+
+
+# Test cases that require the two-way talk browser verification server.
+TWO_WAY_TALK_TEST_IDS: frozenset[str] = frozenset({"TC_WEBRTC_1_6"})
+
+
+def _contains_webrtc_two_way_talk(selected_tests: dict[str, Any]) -> bool:
+    """Return True if any two-way talk test is among the selected tests."""
+    return any(_dict_contains_key(selected_tests, tc) for tc in TWO_WAY_TALK_TEST_IDS)
+
+
+def _dict_contains_key(d: Any, target: str) -> bool:
+    """Recursively search a nested dict for a specific key."""
+    if isinstance(d, dict):
+        if target in d:
+            return True
+        return any(_dict_contains_key(v, target) for v in d.values())
+    return False
+
+
+async def _print_webrtc_banner_and_wait(hostname: str, handler: Any) -> None:
+    """Print a prominent banner for TC-WEBRTC-1.6 and wait until the browser opens the page."""
+    import socket as _socket
+
+    import th_cli.test_run.camera.two_way_talk_handler as _twt_mod
+
+    # Resolve to actual LAN IP if hostname resolves to any loopback address
+    try:
+        resolved = _socket.gethostbyname(hostname)
+    except Exception:
+        resolved = hostname
+    if resolved.startswith("127.") or resolved == "::1":
+        hostname = _twt_mod._get_local_ip()
+
+    url = f"http://{hostname}:8999"
+    border = click.style("═" * 57, fg="yellow", bold=True)
+    click.echo(border)
+    click.echo(click.style("  ⚠  WebRTC Two-Way Talk — Action Required  ⚠", fg="yellow", bold=True))
+    click.echo(border)
+    click.echo(click.style("  Open this URL in a browser NOW and keep it open:", fg="bright_white", bold=True))
+    click.echo("  " + click.style(f"{url}", fg="cyan", bold=True, underline=True))
+    click.echo(click.style("  The page will connect to the DUT automatically.", fg="bright_white"))
+    click.echo(click.style("  You will be asked to select PASS or FAIL during the test.", fg="bright_white"))
+    click.echo(border)
+    click.echo("")
+
+    click.echo(click.style("  Waiting for browser to open the page...", fg="yellow"))
+    connected = await asyncio.get_event_loop().run_in_executor(None, handler.wait_for_browser, 120.0)
+    if connected:
+        click.echo(click.style("  ✔ Browser connected — starting test.", fg="green", bold=True))
+    else:
+        click.echo(click.style("  ⚠ Browser not detected — proceeding anyway.", fg="yellow", bold=True))
+    click.echo("")
 
 
 def _parse_extra_args(args: list[str]) -> dict[str, str]:

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -47,6 +47,7 @@ JSON_INDENT = 2
 # Test cases that require the two-way talk browser verification server.
 TWO_WAY_TALK_TEST_IDS: frozenset[str] = frozenset({"TC_WEBRTC_1_6"})
 
+
 @click.command(
     no_args_is_help=True,
     short_help=colorize_help("CLI execution of a test run"),
@@ -198,7 +199,7 @@ async def run_tests(
             await _print_webrtc_banner_and_wait(th_config.hostname, _webrtc_handler)
         else:
             _webrtc_handler = None
-        socket = TestRunSocket(new_test_run, test_run_config)
+        socket = TestRunSocket(new_test_run, test_run_config, two_way_talk_handler=_webrtc_handler)
         socket_task = asyncio.create_task(socket.connect_websocket())
         new_test_run = await _start_test_run(async_apis, new_test_run)
         socket.run = new_test_run
@@ -242,6 +243,7 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
             click.echo(colorize_key_value("Warning:", msg))
 
     return await projects_api.default_config_api_v1_projects_default_config_get()
+
 
 def _contains_webrtc_two_way_talk(selected_tests: dict[str, Any]) -> bool:
     """Return True if any two-way talk test is among the selected tests."""

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -266,7 +266,7 @@ async def _print_webrtc_banner_and_wait(hostname: str, handler: Any) -> None:
     # Resolve to actual LAN IP if hostname resolves to any loopback address
     try:
         resolved = _socket.gethostbyname(hostname)
-    except Exception:
+    except _socket.gaierror:
         resolved = hostname
     if resolved.startswith("127.") or resolved == "::1":
         hostname = _twt_mod._get_local_ip()

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -17,11 +17,13 @@ import asyncio
 import copy
 import datetime
 import json
+import socket as _socket
 from typing import Any
 
 import click
 
 import th_cli.api_lib_autogen.models as m
+import th_cli.test_run.camera.two_way_talk_handler as _twt_mod
 import th_cli.test_run.logging as test_logging
 from th_cli.api_lib_autogen.api_client import AsyncApis
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
@@ -37,6 +39,7 @@ from th_cli.colorize import (
 )
 from th_cli.config import config as th_config
 from th_cli.exceptions import CLIError, handle_api_error
+from th_cli.test_run.camera.two_way_talk_handler import TwoWayTalkHandler
 from th_cli.test_run.websocket import TestRunSocket
 from th_cli.utils import build_test_selection, convert_nested_to_dict, load_json_config, merge_configs, read_pics_config
 from th_cli.validation import validate_directory_path, validate_file_path, validate_test_ids
@@ -192,8 +195,6 @@ async def run_tests(
             project_id=project_id,
         )
         if _contains_webrtc_two_way_talk(selected_tests_dict):
-            from th_cli.test_run.camera.two_way_talk_handler import TwoWayTalkHandler
-
             _webrtc_handler = TwoWayTalkHandler(port=8999)
             _webrtc_handler.start_waiting()
             await _print_webrtc_banner_and_wait(th_config.hostname, _webrtc_handler)
@@ -261,10 +262,6 @@ def _dict_contains_key(d: Any, target: str) -> bool:
 
 async def _print_webrtc_banner_and_wait(hostname: str, handler: Any) -> None:
     """Print a prominent banner for two-way talk tests and wait until the browser opens the page."""
-    import socket as _socket
-
-    import th_cli.test_run.camera.two_way_talk_handler as _twt_mod
-
     # Resolve to actual LAN IP if hostname resolves to any loopback address
     try:
         resolved = _socket.gethostbyname(hostname)

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -44,6 +44,8 @@ from th_cli.validation import validate_directory_path, validate_file_path, valid
 # Constants
 JSON_INDENT = 2
 
+# Test cases that require the two-way talk browser verification server.
+TWO_WAY_TALK_TEST_IDS: frozenset[str] = frozenset({"TC_WEBRTC_1_6"})
 
 @click.command(
     no_args_is_help=True,
@@ -241,11 +243,6 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
 
     return await projects_api.default_config_api_v1_projects_default_config_get()
 
-
-# Test cases that require the two-way talk browser verification server.
-TWO_WAY_TALK_TEST_IDS: frozenset[str] = frozenset({"TC_WEBRTC_1_6"})
-
-
 def _contains_webrtc_two_way_talk(selected_tests: dict[str, Any]) -> bool:
     """Return True if any two-way talk test is among the selected tests."""
     return any(_dict_contains_key(selected_tests, tc) for tc in TWO_WAY_TALK_TEST_IDS)
@@ -261,7 +258,7 @@ def _dict_contains_key(d: Any, target: str) -> bool:
 
 
 async def _print_webrtc_banner_and_wait(hostname: str, handler: Any) -> None:
-    """Print a prominent banner for TC-WEBRTC-1.6 and wait until the browser opens the page."""
+    """Print a prominent banner for two-way talk tests and wait until the browser opens the page."""
     import socket as _socket
 
     import th_cli.test_run.camera.two_way_talk_handler as _twt_mod

--- a/th_cli/test_run/camera/two_way_talk_handler.py
+++ b/th_cli/test_run/camera/two_way_talk_handler.py
@@ -50,6 +50,8 @@ class TwoWayTalkHTTPHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         if self.path == "/submit_response":
             self._handle_response()
+        elif self.path == "/browser_ready":
+            self._handle_browser_ready()
         else:
             self.send_error(404)
 
@@ -74,10 +76,7 @@ class TwoWayTalkHTTPHandler(BaseHTTPRequestHandler):
             )
         except Exception as e:
             logger.error(f"Failed to load two-way talk HTML template: {e}")
-            page = (
-                "<html><body><h1>Two-Way Talk Verification</h1>"
-                f"<p>Template error: {e}</p></body></html>"
-            )
+            page = "<html><body><h1>Two-Way Talk Verification</h1>" f"<p>Template error: {e}</p></body></html>"
 
         encoded = page.encode("utf-8")
         self.send_response(200)
@@ -140,6 +139,17 @@ class TwoWayTalkHTTPHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(f'{{"error": "{e}"}}'.encode())
 
+    def _handle_browser_ready(self):
+        """Called by the browser page on load to signal the user has it open."""
+        browser_event = getattr(self.server, "browser_ready_event", None)
+        if browser_event:
+            browser_event.set()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(b'{"status": "ok"}')
+
     def log_message(self, format, *args):
         pass  # suppress HTTP access logs
 
@@ -190,6 +200,7 @@ class TwoWayTalkHandler:
         self.port = port
         self._server: Optional[ThreadingHTTPServer] = None
         self._response_queue: queue.Queue = queue.Queue()
+        self._browser_ready_event: threading.Event = threading.Event()
 
     @staticmethod
     def _free_port(port: int) -> None:
@@ -215,6 +226,7 @@ class TwoWayTalkHandler:
         self._server.prompt_options = {}
         self._server.prompt_ready = False
         self._server.response_queue = self._response_queue
+        self._server.browser_ready_event = self._browser_ready_event
         self._server.th_hostname = _get_local_ip()
 
         t = threading.Thread(target=self._server.serve_forever, daemon=True)
@@ -235,6 +247,11 @@ class TwoWayTalkHandler:
         Use this when the current process may already be listening on the port
         (e.g. fallback path where start_waiting() was not called earlier)."""
         self._start_server()
+
+    def wait_for_browser(self, timeout: float = 120.0) -> bool:
+        """Block until the browser page loads and posts /browser_ready.
+        Returns True if browser connected, False if timed out."""
+        return self._browser_ready_event.wait(timeout=timeout)
 
     def show_prompt(self, prompt_text: str, prompt_options: dict) -> None:
         """Reveal the PASS/FAIL prompt in the browser (called at step 8)."""

--- a/th_cli/test_run/camera/two_way_talk_handler.py
+++ b/th_cli/test_run/camera/two_way_talk_handler.py
@@ -131,7 +131,7 @@ class TwoWayTalkHTTPHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(b'{"status": "success"}')
 
-        except Exception as e:
+        except (json.JSONDecodeError, ValueError) as e:
             logger.error(f"TwoWayTalk response handler error: {e}")
             self.send_response(500)
             self.send_header("Content-Type", "application/json")

--- a/th_cli/test_run/camera/two_way_talk_handler.py
+++ b/th_cli/test_run/camera/two_way_talk_handler.py
@@ -1,0 +1,275 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import asyncio
+import json
+import queue
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+
+
+def _get_local_ip() -> str:
+    """Get the LAN IP of this machine."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception:
+        return "127.0.0.1"
+
+
+class TwoWayTalkHTTPHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the two-way talk verification page."""
+
+    def do_GET(self):
+        if self.path == "/" or self.path.startswith("/?"):
+            self._serve_page()
+        elif self.path == "/prompt_ready":
+            self._serve_prompt_ready()
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path == "/submit_response":
+            self._handle_response()
+        else:
+            self.send_error(404)
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def _serve_page(self):
+        prompt_ready = getattr(self.server, "prompt_ready", False)
+        th_hostname = getattr(self.server, "th_hostname", "127.0.0.1")
+
+        try:
+            template_path = Path(__file__).parent / "two_way_talk_verification.html"
+            with open(template_path, "r", encoding="utf-8") as f:
+                template = f.read()
+            page = template.format(
+                th_hostname=th_hostname,
+                prompt_ready="true" if prompt_ready else "false",
+            )
+        except Exception as e:
+            logger.error(f"Failed to load two-way talk HTML template: {e}")
+            page = (
+                "<html><body><h1>Two-Way Talk Verification</h1>"
+                f"<p>Template error: {e}</p></body></html>"
+            )
+
+        encoded = page.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _serve_prompt_ready(self):
+        """JSON endpoint polled by the browser to know when the prompt is ready.
+        When ready, also returns the prompt text and options so the browser can
+        render radio buttons dynamically (avoids stale server-side HTML baked at
+        page-load time when options were not yet set)."""
+        ready = getattr(self.server, "prompt_ready", False)
+        payload = {"ready": ready}
+        if ready:
+            payload["prompt_text"] = getattr(self.server, "prompt_text", "")
+            payload["options"] = getattr(self.server, "prompt_options", {})
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _handle_response(self):
+        try:
+            if "Content-Length" not in self.headers:
+                self.send_error(400, "Missing Content-Length")
+                return
+            content_length = int(self.headers["Content-Length"])
+            body = self.rfile.read(content_length)
+            data = json.loads(body.decode("utf-8"))
+            raw = data.get("response")
+            if raw is None:
+                raise ValueError("Missing 'response' key")
+            value = int(raw)
+
+            response_queue = getattr(self.server, "response_queue", None)
+            if response_queue:
+                response_queue.put_nowait(value)
+            else:
+                self.send_error(500, "No response queue")
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(b'{"status": "success"}')
+
+        except Exception as e:
+            logger.error(f"TwoWayTalk response handler error: {e}")
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(f'{{"error": "{e}"}}'.encode())
+
+    def log_message(self, format, *args):
+        pass  # suppress HTTP access logs
+
+
+# Module-level singletons
+_active_handler: Optional["TwoWayTalkHandler"] = None
+# Also keep a direct reference to the running HTTP server so show_prompt can be
+# called even if the handler object reference is lost (e.g. module import edge cases).
+_active_server: Optional["_ReuseAddrHTTPServer"] = None
+
+
+def get_active_handler() -> Optional["TwoWayTalkHandler"]:
+    return _active_handler
+
+
+def set_active_handler(handler: Optional["TwoWayTalkHandler"]) -> None:
+    global _active_handler
+    _active_handler = handler
+
+
+def show_prompt_on_active_server(prompt_text: str, prompt_options: dict) -> bool:
+    """Call show_prompt on the currently running HTTP server regardless of handler state.
+    Returns True if the server was found and updated, False otherwise."""
+    if _active_server is not None:
+        _active_server.prompt_text = prompt_text
+        _active_server.prompt_options = prompt_options
+        _active_server.prompt_ready = True
+        logger.debug("TwoWayTalk prompt updated via module-level server reference")
+        return True
+    return False
+
+
+class _ReuseAddrHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer with allow_reuse_address set before server_bind()."""
+
+    allow_reuse_address = True
+
+
+class TwoWayTalkHandler:
+    """Manages the local HTTP server for two-way talk verification.
+
+    Start with start_waiting() before the test begins — the browser connects
+    as the WebRTC peer and shows the live session.  When step 8 arrives call
+    show_prompt() to reveal the PASS/FAIL form in the browser.
+    """
+
+    def __init__(self, port: int = 8999):
+        self.port = port
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._response_queue: queue.Queue = queue.Queue()
+
+    @staticmethod
+    def _free_port(port: int) -> None:
+        """Kill any process that is still listening on the given port."""
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["fuser", "-k", f"{port}/tcp"],
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                logger.info(f"Freed port {port} from previous process")
+                time.sleep(0.5)  # give the OS a moment to release the socket
+        except FileNotFoundError:
+            pass  # fuser not available on this platform
+
+    def _start_server(self) -> None:
+        """Bind and start the HTTP server thread.  Does NOT free the port first."""
+        global _active_server
+        self._server = _ReuseAddrHTTPServer(("0.0.0.0", self.port), TwoWayTalkHTTPHandler)
+        self._server.prompt_text = "Verify two-way talk"
+        self._server.prompt_options = {}
+        self._server.prompt_ready = False
+        self._server.response_queue = self._response_queue
+        self._server.th_hostname = _get_local_ip()
+
+        t = threading.Thread(target=self._server.serve_forever, daemon=True)
+        t.start()
+        logger.info(f"TwoWayTalk HTTP server started on port {self.port}")
+        _active_server = self._server
+        set_active_handler(self)
+
+    def start_waiting(self) -> None:
+        """Start the HTTP server before the test.  Prompt is hidden until show_prompt().
+        Kills any zombie process still holding the port first (safe to call before the
+        server is bound — the current process does not hold the port yet)."""
+        self._free_port(self.port)
+        self._start_server()
+
+    def start_server_only(self) -> None:
+        """Start the HTTP server WITHOUT killing the port first.
+        Use this when the current process may already be listening on the port
+        (e.g. fallback path where start_waiting() was not called earlier)."""
+        self._start_server()
+
+    def show_prompt(self, prompt_text: str, prompt_options: dict) -> None:
+        """Reveal the PASS/FAIL prompt in the browser (called at step 8)."""
+        if self._server:
+            self._server.prompt_text = prompt_text
+            self._server.prompt_options = prompt_options
+            self._server.prompt_ready = True
+            logger.debug("TwoWayTalk prompt is now visible")
+
+    # Keep backward-compat alias used by old prompt_manager code
+    def start(self, prompt_text: str, prompt_options: dict) -> None:
+        self.start_waiting()
+        self.show_prompt(prompt_text, prompt_options)
+
+    def update_prompt(self, prompt_text: str, prompt_options: dict) -> None:
+        self.show_prompt(prompt_text, prompt_options)
+
+    def stop(self) -> None:
+        global _active_server
+        set_active_handler(None)
+        _active_server = None
+        if self._server:
+            try:
+                self._server.shutdown()
+            except Exception as e:
+                logger.debug(f"Error stopping TwoWayTalk server: {e}")
+            finally:
+                self._server = None
+
+    async def wait_for_user_response(self, timeout: float) -> Optional[int]:
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                return self._response_queue.get_nowait()
+            except queue.Empty:
+                await asyncio.sleep(0.1)
+        logger.warning("TwoWayTalk user response timed out")
+        return None

--- a/th_cli/test_run/camera/two_way_talk_verification.html
+++ b/th_cli/test_run/camera/two_way_talk_verification.html
@@ -722,6 +722,8 @@
 
     // ── Init ──────────────────────────────────────────────────────────────────
     window.addEventListener("load", () => {{
+        // Notify the CLI that the browser has opened the page
+        fetch("/browser_ready", {{ method: "POST" }}).catch(() => {{}});
         connect();
         if (!promptReady) pollPrompt();
     }});

--- a/th_cli/test_run/camera/two_way_talk_verification.html
+++ b/th_cli/test_run/camera/two_way_talk_verification.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Two-Way Talk Verification</title>
+    <style>
+        body {{
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f5f5f5;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }}
+        .matter-header {{
+            background: white;
+            border-bottom: 1px solid #e0e0e0;
+            padding: 12px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .header-title {{ font-size: 18px; font-weight: 600; color: #333; margin: 0; }}
+        .cli-indicator {{
+            background: #2196F3; color: white; padding: 4px 8px;
+            border-radius: 12px; font-size: 11px; font-weight: 500;
+        }}
+        .content {{
+            flex: 1; display: flex; flex-direction: column;
+            align-items: center; padding: 24px 20px;
+        }}
+        .card {{
+            background: white; border-radius: 8px; padding: 20px 24px;
+            margin-bottom: 20px; width: 100%; max-width: 680px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+        }}
+        .card-title {{
+            font-size: 13px; font-weight: 600; color: #555;
+            text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 14px 0;
+        }}
+        .prompt-text {{ font-size: 16px; color: #333; line-height: 1.5; margin: 0 0 10px 0; }}
+        .waiting-banner {{
+            background: #fff8e1; border-left: 4px solid #FFC107;
+            border-radius: 0 4px 4px 0; padding: 12px 16px;
+            font-size: 14px; color: #795548; line-height: 1.5;
+        }}
+        video {{
+            width: 100%; max-width: 640px; height: 360px;
+            background: #1e1e1e; border-radius: 6px; display: block;
+            margin-bottom: 14px;
+        }}
+        .state-row {{
+            font-size: 13px; color: #666; margin-bottom: 10px;
+        }}
+        .state-row span {{
+            font-weight: 600;
+            padding: 2px 8px; border-radius: 10px; font-size: 12px;
+        }}
+        .state-connected {{ background: #e8f5e9; color: #2e7d32; }}
+        .state-connecting {{ background: #e3f2fd; color: #1565c0; }}
+        .state-failed {{ background: #ffebee; color: #c62828; }}
+        .state-closed {{ background: #f3e5f5; color: #6a1b9a; }}
+        .state-default {{ background: #f5f5f5; color: #555; }}
+        .audio-row {{
+            display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+        }}
+        .audio-label {{ font-size: 13px; color: #444; min-width: 120px; }}
+        .audio-bar-bg {{
+            flex: 1; height: 10px; background: #e0e0e0;
+            border-radius: 5px; overflow: hidden;
+        }}
+        .audio-bar-fill {{
+            height: 100%; border-radius: 5px;
+            transition: width 0.1s, background-color 0.1s;
+            width: 0%;
+        }}
+        .audio-val {{ font-size: 12px; color: #666; min-width: 36px; text-align: right; }}
+        .radio-options {{ display: flex; flex-direction: column; gap: 10px; }}
+        .radio-row {{
+            background: white; border: 2px solid #e0e0e0; border-radius: 8px;
+            padding: 14px 18px; cursor: pointer; display: flex; align-items: center;
+            gap: 12px; transition: border-color 0.2s, background 0.2s; font-size: 15px;
+        }}
+        .radio-row:hover {{ border-color: #2196F3; background: #f0f7ff; }}
+        .radio-row.selected {{ border-color: #2196F3; background: #e3f2fd; }}
+        .radio-row input[type=radio] {{ accent-color: #2196F3; width: 18px; height: 18px; }}
+        .submit-btn {{
+            display: block; width: 100%; padding: 14px; margin-top: 14px;
+            background: #2196F3; color: white; border: none; border-radius: 8px;
+            font-size: 16px; font-weight: 600; cursor: pointer; transition: background 0.2s;
+        }}
+        .submit-btn:hover {{ background: #1976D2; }}
+        .submit-btn:disabled {{ background: #90CAF9; cursor: not-allowed; }}
+        #actionCard {{ display: none; }}
+    </style>
+</head>
+<body>
+
+<div class="matter-header">
+    <span class="header-title">🎤 Two-Way Talk Verification</span>
+    <span class="cli-indicator">CLI Mode</span>
+</div>
+
+<div class="content">
+
+    <!-- Video + audio levels (shown once peer connected) -->
+    <div class="card" id="mediaCard" style="display:none;">
+        <p class="card-title">Live Session</p>
+        <video id="remoteVideo" autoplay playsinline muted></video>
+
+        <div class="state-row">
+            Peer Connection State: <span id="peerState" class="state-default">—</span>
+            &nbsp; <button id="unmuteBtn" onclick="unmuteVideo()" style="display:none;padding:4px 10px;font-size:12px;cursor:pointer;">🔊 Unmute</button>
+        </div>
+
+        <div class="audio-row">
+            <span class="audio-label">🔈 Speaker (DUT→you)</span>
+            <div class="audio-bar-bg"><div class="audio-bar-fill" id="remoteBar"></div></div>
+            <span class="audio-val" id="remoteVal">0%</span>
+        </div>
+        <div class="audio-row">
+            <span class="audio-label">🎙️ Mic (you→DUT)</span>
+            <div class="audio-bar-bg"><div class="audio-bar-fill" id="localBar"></div></div>
+            <span class="audio-val" id="localVal">0%</span>
+        </div>
+    </div>
+
+    <!-- Waiting state (shown before peer connects) -->
+    <div class="card" id="waitCard">
+        <div class="waiting-banner">
+            ⏳ Waiting for the test to start the WebRTC session…<br>
+            Keep this page open. Audio and video will appear automatically.
+        </div>
+    </div>
+
+    <!-- PASS/FAIL prompt (shown when test reaches step 8) -->
+    <div class="card" id="actionCard">
+        <p class="card-title">Verification</p>
+        <p class="prompt-text" id="promptText"></p>
+        <div class="radio-options" id="radioOptions">
+        </div>
+        <button class="submit-btn" id="submitBtn" onclick="submitResponse()" disabled>Submit Response</button>
+    </div>
+
+</div>
+
+
+<script>
+    // ── Config ────────────────────────────────────────────────────────────────
+    const WS_URL    = "ws://{th_hostname}/api/v1/ws/webrtc/peer";
+    const TH_LAN_IP = "{th_hostname}";  // real LAN IP injected server-side
+    // Use public STUN only to discover the browser's ephemeral port.
+    // We replace the public srflx IP with TH_LAN_IP before sending to the DUT
+    // so ICE stays on the local network and avoids the OOM-triggering public path.
+    const ICE_SERVERS = [
+        {{ urls: "stun:stun.l.google.com:19302" }},
+    ];
+
+    // ── State ─────────────────────────────────────────────────────────────────
+    let ws = null, wsRetry = null;
+    let sessions = {{}};        // sessionId -> RTCPeerConnection
+    let remoteStreams = {{}};    // sessionId -> MediaStream (single stream with all remote tracks)
+    let localStream = null;
+    let audioCtx = null, localAnalyser = null, remoteAnalyser = null, animId = null;
+    let selectedValue = null;
+    let promptReady = {prompt_ready};   // False until server sets prompt; injected server-side
+
+    // ── UI helpers ────────────────────────────────────────────────────────────
+    function setPeerState(state) {{
+        const el = document.getElementById("peerState");
+        el.textContent = state.toUpperCase();
+        el.className = {{
+            "connected":    "state-connected",
+            "connecting":   "state-connecting",
+            "failed":       "state-failed",
+            "disconnected": "state-failed",
+            "closed":       "state-closed",
+        }}[state] || "state-default";
+        if (state === "connected") {{
+            document.getElementById("waitCard").style.display  = "none";
+            document.getElementById("mediaCard").style.display = "block";
+            document.getElementById("unmuteBtn").style.display = "inline-block";
+            if (promptReady) document.getElementById("actionCard").style.display = "block";
+            // Resume AudioContext now that we have user-context via WebRTC activity
+            if (audioCtx && audioCtx.state === "suspended") audioCtx.resume();
+        }}
+    }}
+
+    function unmuteVideo() {{
+        const v = document.getElementById("remoteVideo");
+        v.muted = !v.muted;
+        document.getElementById("unmuteBtn").textContent = v.muted ? "🔊 Unmute" : "🔇 Mute";
+        if (audioCtx && audioCtx.state === "suspended") audioCtx.resume();
+    }}
+
+    function showPrompt(promptText, options) {{
+        promptReady = true;
+        // Populate prompt text
+        document.getElementById("promptText").textContent = promptText || "Verify two-way talk";
+        // Render radio buttons dynamically from server data
+        const container = document.getElementById("radioOptions");
+        container.innerHTML = "";
+        for (const [label, value] of Object.entries(options || {{}})) {{
+            const div = document.createElement("div");
+            div.className = "radio-row";
+            div.dataset.value = value;
+            div.onclick = () => selectOption(value);
+            div.innerHTML = `<input type="radio" name="option" value="${{value}}" id="radio_${{value}}">` +
+                             `<label for="radio_${{value}}">${{label}}</label>`;
+            container.appendChild(div);
+        }}
+        // Show actionCard if WebRTC is already connected
+        if (document.getElementById("mediaCard").style.display === "block") {{
+            document.getElementById("actionCard").style.display = "block";
+        }}
+    }}
+
+    // ── Audio analysers ───────────────────────────────────────────────────────
+    function getAudioCtx() {{ return audioCtx || (audioCtx = new AudioContext()); }}
+
+    function attachAnalyser(stream, type) {{
+        try {{
+            const ctx = getAudioCtx();
+            const a = ctx.createAnalyser();
+            a.fftSize = 256; a.smoothingTimeConstant = 0.8;
+            ctx.createMediaStreamSource(stream).connect(a);
+            if (type === "local")  localAnalyser  = a;
+            else                   remoteAnalyser = a;
+            if (!animId) animateLevels();
+        }} catch(e) {{ console.warn("Analyser error:", e); }}
+    }}
+
+    function rmsLevel(analyser) {{
+        if (!analyser) return 0;
+        const d = new Uint8Array(analyser.fftSize);
+        analyser.getByteTimeDomainData(d);
+        let s = 0;
+        for (const v of d) {{ const x = (v-128)/128; s += x*x; }}
+        return Math.min(100, Math.sqrt(s/d.length)*200);
+    }}
+
+    function levelColor(pct) {{
+        if (pct < 30) return "#4CAF50";
+        if (pct < 70) return "#FFC107";
+        return "#f44336";
+    }}
+
+    function animateLevels() {{
+        const r = Math.round(rmsLevel(remoteAnalyser));
+        const l = Math.round(rmsLevel(localAnalyser));
+        const rb = document.getElementById("remoteBar");
+        const lb = document.getElementById("localBar");
+        rb.style.width = r+"%"; rb.style.backgroundColor = levelColor(r);
+        lb.style.width = l+"%"; lb.style.backgroundColor = levelColor(l);
+        document.getElementById("remoteVal").textContent = r+"%";
+        document.getElementById("localVal").textContent  = l+"%";
+        animId = requestAnimationFrame(animateLevels);
+    }}
+
+    // ── Mic ───────────────────────────────────────────────────────────────────
+    async function ensureMic() {{
+        if (localStream) return localStream;
+        if (!navigator.mediaDevices?.getUserMedia) return null;
+        try {{
+            localStream = await navigator.mediaDevices.getUserMedia({{audio:true, video:false}});
+            attachAnalyser(localStream, "local");
+            return localStream;
+        }} catch(e) {{ console.warn("Mic denied:", e); return null; }}
+    }}
+
+    // ── RTCPeerConnection per session ─────────────────────────────────────────
+    async function getOrCreate(sessionId, msg) {{
+        if (sessions[sessionId]) return sessions[sessionId];
+        if (msg.type !== "CREATE_PEER_CONNECTION") {{
+            sendWS(reply(msg, null, "No peer for session "+sessionId)); return null;
+        }}
+        const mic = await ensureMic();
+        const pc = new RTCPeerConnection({{iceServers: ICE_SERVERS}});
+        sessions[sessionId] = pc;
+
+        pc.addTransceiver("audio", {{direction:"sendrecv"}});
+        pc.addTransceiver("video", {{direction:"recvonly"}});
+
+        if (mic) mic.getTracks().forEach(t => pc.addTrack(t, mic));
+
+        pc.onicecandidate = e => {{
+            if (e.candidate && e.candidate.candidate !== "") {{
+                const cand = e.candidate.candidate;
+                // Skip mDNS .local candidates — DUT container cannot resolve them
+                if (cand.includes(".local")) return;
+
+                let finalCand = cand;
+                // If this is a srflx candidate from public STUN, replace the
+                // public IP with the TH LAN IP so ICE stays on the local network.
+                // Extract the port from the srflx candidate and emit a host candidate
+                // with TH_LAN_IP instead — the DUT and TH are on the same LAN.
+                if (cand.includes("typ srflx") && TH_LAN_IP) {{
+                    const portMatch = cand.match(/^(candidate:\S+)\s+(\d+)\s+(\w+)\s+\d+\s+\S+\s+(\d+)\s+typ srflx/);
+                    if (portMatch) {{
+                        const [, foundation, component, proto, port] = portMatch;
+                        finalCand = `${{foundation}} ${{component}} ${{proto}} 2113937151 ${{TH_LAN_IP}} ${{port}} typ host generation 0`;
+                    }}
+                }}
+
+                sendWS(reply(msg,
+                    {{candidate: finalCand,
+                      sdpMLineIndex: e.candidate.sdpMLineIndex,
+                      sdpMid: e.candidate.sdpMid}},
+                    null, "LOCAL_ICE_CANDIDATES"));
+            }}
+        }};
+
+        pc.onicegatheringstatechange = () => {{
+            if (pc.iceGatheringState === "complete")
+                sendWS(reply(msg, null, null, "GATHERING_STATE_COMPLETE"));
+        }};
+
+        pc.onconnectionstatechange = () => {{
+            const s = pc.connectionState;
+            setPeerState(s);
+            sendWS(reply(msg, s, null, "PEER_CONNECTION_STATE"));
+        }};
+
+        // Pre-create a single MediaStream — add every incoming track to it,
+        // matching Angular's WebRTCService pattern exactly.
+        const remoteStream = new MediaStream();
+        remoteStreams[sessionId] = remoteStream;
+        document.getElementById("remoteVideo").srcObject = remoteStream;
+
+        pc.ontrack = e => {{
+            remoteStream.addTrack(e.track);
+            // Refresh srcObject so the video element picks up the new track
+            document.getElementById("remoteVideo").srcObject = remoteStream;
+
+            if (e.track.kind === "audio") {{
+                // Use a separate single-track stream for the analyser only
+                const audioStream = new MediaStream([e.track]);
+                attachAnalyser(audioStream, "remote");
+            }}
+        }};
+
+        return pc;
+    }}
+
+    // ── WebRTC message dispatch ───────────────────────────────────────────────
+    async function dispatch(msg) {{
+        const {{type, sessionId, data}} = msg;
+        if (!sessionId) {{ sendWS(reply(msg, null, "Missing sessionId")); return; }}
+
+        let pc = sessions[sessionId];
+        if (!pc && type !== "CREATE_PEER_CONNECTION") {{
+            if (type === "CLOSE_PEER_CONNECTION") return;
+            sendWS(reply(msg, null, "No session "+sessionId+" for "+type)); return;
+        }}
+
+        try {{
+            switch(type) {{
+                case "CREATE_PEER_CONNECTION":
+                    pc = await getOrCreate(sessionId, msg);
+                    if (pc) sendWS(reply(msg));
+                    break;
+                case "CREATE_OFFER": {{
+                    const offer = await pc.createOffer();
+                    await pc.setLocalDescription(offer);
+                    sendWS(reply(msg, offer.sdp));
+                    break;
+                }}
+                case "CREATE_ANSWER": {{
+                    const ans = await pc.createAnswer();
+                    await pc.setLocalDescription(ans);
+                    sendWS(reply(msg, ans.sdp));
+                    break;
+                }}
+                case "SET_REMOTE_OFFER":
+                    await pc.setRemoteDescription(new RTCSessionDescription({{type:"offer", sdp:data}}));
+                    sendWS(reply(msg));
+                    break;
+                case "SET_REMOTE_ANSWER":
+                    await pc.setRemoteDescription(new RTCSessionDescription({{type:"answer", sdp:data}}));
+                    sendWS(reply(msg));
+                    break;
+                case "SET_REMOTE_ICE_CANDIDATES":
+                    for (const c of data)
+                        await pc.addIceCandidate(new RTCIceCandidate({{
+                            candidate: c.candidate,
+                            sdpMLineIndex: c.sdpMLineIndex ?? 0,
+                            sdpMid: c.sdpMid ?? "0",
+                        }}));
+                    sendWS(reply(msg));
+                    break;
+                case "GET_PEER_CONNECTION_STATE":
+                    sendWS(reply(msg, pc.connectionState));
+                    break;
+                case "GET_LOCAL_DESCRIPTION":
+                    sendWS(reply(msg, pc.localDescription));
+                    break;
+                case "CLOSE_PEER_CONNECTION":
+                    pc.close();
+                    delete sessions[sessionId];
+                    delete remoteStreams[sessionId];
+                    setPeerState("closed");
+                    break;
+                default:
+                    sendWS(reply(msg, null, "Unknown type: "+type));
+            }}
+        }} catch(e) {{
+            sendWS(reply(msg, null, "Error in "+type+": "+e));
+        }}
+    }}
+
+    // ── WebSocket ─────────────────────────────────────────────────────────────
+    function reply(req, data, error, optType) {{
+        return {{type: optType||req.type, sessionId:req.sessionId,
+                 data: data!==undefined ? data : null, error: error||null}};
+    }}
+
+    function sendWS(msg) {{
+        if (ws?.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+    }}
+
+    function connect() {{
+        if (wsRetry) {{ clearTimeout(wsRetry); wsRetry = null; }}
+        ws = new WebSocket(WS_URL);
+        ws.onopen    = () => console.log("[WS] connected");
+        ws.onclose   = () => {{ wsRetry = setTimeout(connect, 2000); }};
+        ws.onerror   = () => {{}};
+        ws.onmessage = async e => {{
+            let msg;
+            try {{ msg = JSON.parse(e.data); }} catch {{ return; }}
+            await dispatch(msg);
+        }};
+    }}
+
+    // ── Prompt PASS/FAIL ──────────────────────────────────────────────────────
+    function selectOption(value) {{
+        selectedValue = value;
+        document.querySelectorAll(".radio-row").forEach(r => {{
+            r.classList.toggle("selected", parseInt(r.dataset.value)===value);
+            r.querySelector("input").checked = (parseInt(r.dataset.value)===value);
+        }});
+        document.getElementById("submitBtn").disabled = false;
+    }}
+
+    function submitResponse() {{
+        if (selectedValue === null) return;
+        fetch("/submit_response", {{
+            method: "POST",
+            headers: {{"Content-Type": "application/json"}},
+            body: JSON.stringify({{response: selectedValue}})
+        }})
+        .then(r => r.json())
+        .then(() => {{
+            document.getElementById("submitBtn").disabled = true;
+            document.getElementById("submitBtn").textContent = "✅ Response Submitted";
+        }})
+        .catch(e => alert("Failed to submit: "+e));
+    }}
+
+    // ── Poll server for prompt readiness ──────────────────────────────────────
+    function pollPrompt() {{
+        if (promptReady) return;
+        fetch("/prompt_ready")
+            .then(r => r.json())
+            .then(d => {{
+                if (d.ready) showPrompt(d.prompt_text, d.options);
+                else setTimeout(pollPrompt, 1000);
+            }})
+            .catch(() => setTimeout(pollPrompt, 2000));
+    }}
+
+    // ── Init ──────────────────────────────────────────────────────────────────
+    window.addEventListener("load", () => {{
+        connect();
+        if (!promptReady) pollPrompt();
+    }});
+</script>
+</body>
+</html>

--- a/th_cli/test_run/camera/two_way_talk_verification.html
+++ b/th_cli/test_run/camera/two_way_talk_verification.html
@@ -13,6 +13,7 @@
             flex-direction: column;
             min-height: 100vh;
         }}
+
         .matter-header {{
             background: white;
             border-bottom: 1px solid #e0e0e0;
@@ -22,128 +23,357 @@
             align-items: center;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }}
-        .header-title {{ font-size: 18px; font-weight: 600; color: #333; margin: 0; }}
-        .cli-indicator {{
-            background: #2196F3; color: white; padding: 4px 8px;
-            border-radius: 12px; font-size: 11px; font-weight: 500;
+
+        .header-start {{
+            display: flex;
+            align-items: center;
+            gap: 15px;
         }}
-        .content {{
-            flex: 1; display: flex; flex-direction: column;
-            align-items: center; padding: 24px 20px;
-        }}
-        .card {{
-            background: white; border-radius: 8px; padding: 20px 24px;
-            margin-bottom: 20px; width: 100%; max-width: 680px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.08);
-        }}
-        .card-title {{
-            font-size: 13px; font-weight: 600; color: #555;
-            text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 14px 0;
-        }}
-        .prompt-text {{ font-size: 16px; color: #333; line-height: 1.5; margin: 0 0 10px 0; }}
-        .waiting-banner {{
-            background: #fff8e1; border-left: 4px solid #FFC107;
-            border-radius: 0 4px 4px 0; padding: 12px 16px;
-            font-size: 14px; color: #795548; line-height: 1.5;
-        }}
-        video {{
-            width: 100%; max-width: 640px; height: 360px;
-            background: #1e1e1e; border-radius: 6px; display: block;
-            margin-bottom: 14px;
-        }}
-        .state-row {{
-            font-size: 13px; color: #666; margin-bottom: 10px;
-        }}
-        .state-row span {{
+
+        .header-title {{
+            font-size: 18px;
             font-weight: 600;
-            padding: 2px 8px; border-radius: 10px; font-size: 12px;
+            color: #333;
+            margin: 0;
         }}
+
+        .header-end {{
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }}
+
+        .version-info {{
+            font-size: 12px;
+            color: #666;
+            text-align: right;
+        }}
+
+        .cli-indicator {{
+            background: #2196F3;
+            color: white;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 500;
+        }}
+
+        .main-content {{
+            flex: 1;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+        }}
+
+        .p-dialog {{
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+            max-width: 700px;
+            width: 100%;
+            margin: 20px;
+        }}
+
+        .p-dialog-header {{
+            padding: 16px 20px;
+            border-bottom: 1px solid #e0e0e0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: #fafafa;
+            border-radius: 8px 8px 0 0;
+        }}
+
+        .p-dialog-title {{
+            font-size: 18px;
+            font-weight: 600;
+            color: #333;
+        }}
+
+        .p-dialog-content {{
+            padding: 20px;
+        }}
+
+        .subheader {{
+            font-size: 16px;
+            color: #555;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }}
+
+        .waiting-banner {{
+            background: #fff8e1;
+            border: 1px solid #FFC107;
+            padding: 12px 16px;
+            border-radius: 4px;
+            margin: 0 0 10px 0;
+            font-size: 14px;
+            color: #795548;
+            line-height: 1.5;
+        }}
+
+        .video-container {{
+            text-align: center;
+            margin: 0 0 14px 0;
+            background: #000;
+            border-radius: 4px;
+            padding: 10px;
+        }}
+
+        video {{
+            width: 640px;
+            height: 360px;
+            max-width: 100%;
+            border: 2px solid #ddd;
+            border-radius: 4px;
+            background: #000;
+        }}
+
+        .state-row {{
+            font-size: 13px;
+            color: #666;
+            margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }}
+
+        .state-badge {{
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 12px;
+        }}
+
         .state-connected {{ background: #e8f5e9; color: #2e7d32; }}
         .state-connecting {{ background: #e3f2fd; color: #1565c0; }}
         .state-failed {{ background: #ffebee; color: #c62828; }}
         .state-closed {{ background: #f3e5f5; color: #6a1b9a; }}
         .state-default {{ background: #f5f5f5; color: #555; }}
+
+        .sound-banner {{
+            background: #e3f2fd;
+            border: 1px solid #2196F3;
+            padding: 10px 14px;
+            border-radius: 4px;
+            margin-bottom: 12px;
+            font-size: 14px;
+            color: #1565c0;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }}
+
+        .sound-btn {{
+            background: #2196F3;
+            color: white;
+            border: none;
+            padding: 6px 14px;
+            border-radius: 4px;
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            white-space: nowrap;
+        }}
+
+        .sound-btn:hover {{ background: #1976D2; }}
+
         .audio-row {{
-            display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 8px;
         }}
-        .audio-label {{ font-size: 13px; color: #444; min-width: 120px; }}
+
+        .audio-label {{
+            font-size: 13px;
+            color: #444;
+            min-width: 140px;
+        }}
+
         .audio-bar-bg {{
-            flex: 1; height: 10px; background: #e0e0e0;
-            border-radius: 5px; overflow: hidden;
+            flex: 1;
+            height: 10px;
+            background: #e0e0e0;
+            border-radius: 5px;
+            overflow: hidden;
         }}
+
         .audio-bar-fill {{
-            height: 100%; border-radius: 5px;
+            height: 100%;
+            border-radius: 5px;
             transition: width 0.1s, background-color 0.1s;
             width: 0%;
         }}
-        .audio-val {{ font-size: 12px; color: #666; min-width: 36px; text-align: right; }}
-        .radio-options {{ display: flex; flex-direction: column; gap: 10px; }}
-        .radio-row {{
-            background: white; border: 2px solid #e0e0e0; border-radius: 8px;
-            padding: 14px 18px; cursor: pointer; display: flex; align-items: center;
-            gap: 12px; transition: border-color 0.2s, background 0.2s; font-size: 15px;
+
+        .audio-val {{
+            font-size: 12px;
+            color: #666;
+            min-width: 36px;
+            text-align: right;
         }}
-        .radio-row:hover {{ border-color: #2196F3; background: #f0f7ff; }}
-        .radio-row.selected {{ border-color: #2196F3; background: #e3f2fd; }}
-        .radio-row input[type=radio] {{ accent-color: #2196F3; width: 18px; height: 18px; }}
-        .submit-btn {{
-            display: block; width: 100%; padding: 14px; margin-top: 14px;
-            background: #2196F3; color: white; border: none; border-radius: 8px;
-            font-size: 16px; font-weight: 600; cursor: pointer; transition: background 0.2s;
+
+        .input-items-div {{
+            margin: 20px 0;
         }}
-        .submit-btn:hover {{ background: #1976D2; }}
-        .submit-btn:disabled {{ background: #90CAF9; cursor: not-allowed; }}
-        #actionCard {{ display: none; }}
+
+        .popup-radio-div {{
+            display: flex;
+            gap: 20px;
+            justify-content: center;
+            margin: 20px 0;
+            flex-wrap: wrap;
+        }}
+
+        .popup-radio-row {{
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 15px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.2s;
+            min-width: 100px;
+            justify-content: center;
+        }}
+
+        .popup-radio-row:hover {{
+            background: #f0f0f0;
+            border-color: #2196F3;
+        }}
+
+        .popup-radio-row.selected {{
+            background: #e3f2fd;
+            border-color: #2196F3;
+        }}
+
+        input[type="radio"] {{
+            margin-right: 8px;
+            transform: scale(1.2);
+        }}
+
+        label {{
+            font-weight: 500;
+            color: #333;
+            cursor: pointer;
+            font-size: 14px;
+        }}
+
+        .buttons-div {{
+            text-align: center;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e0e0e0;
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }}
+
+        .popup-button {{
+            background: #2196F3;
+            color: white;
+            border: none;
+            padding: 12px 30px;
+            border-radius: 4px;
+            font-size: 16px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s;
+            min-width: 120px;
+        }}
+
+        .popup-button:hover {{ background: #1976D2; }}
+
+        .popup-button:disabled {{
+            background: #ccc;
+            cursor: not-allowed;
+        }}
+
+        .submitting {{
+            background: #ff9800 !important;
+            cursor: wait !important;
+        }}
     </style>
 </head>
 <body>
 
 <div class="matter-header">
-    <span class="header-title">🎤 Two-Way Talk Verification</span>
-    <span class="cli-indicator">CLI Mode</span>
+    <div class="header-start">
+        <div class="header-title">Matter Certification Tool</div>
+    </div>
+    <div class="header-end">
+        <div class="cli-indicator">CLI</div>
+        <div class="version-info">
+            <div>Two-Way Talk Verification</div>
+            <div style="font-size: 10px; color: #999;">CLI WebRTC Interface</div>
+        </div>
+    </div>
 </div>
 
-<div class="content">
-
-    <!-- Video + audio levels (shown once peer connected) -->
-    <div class="card" id="mediaCard" style="display:none;">
-        <p class="card-title">Live Session</p>
-        <video id="remoteVideo" autoplay playsinline muted></video>
-
-        <div class="state-row">
-            Peer Connection State: <span id="peerState" class="state-default">—</span>
-            &nbsp; <button id="unmuteBtn" onclick="unmuteVideo()" style="display:none;padding:4px 10px;font-size:12px;cursor:pointer;">🔊 Unmute</button>
+<div class="main-content">
+    <div class="p-dialog" role="dialog">
+        <div class="p-dialog-header">
+            <span class="p-dialog-title">Two-Way Talk Verification</span>
         </div>
 
-        <div class="audio-row">
-            <span class="audio-label">🔈 Speaker (DUT→you)</span>
-            <div class="audio-bar-bg"><div class="audio-bar-fill" id="remoteBar"></div></div>
-            <span class="audio-val" id="remoteVal">0%</span>
-        </div>
-        <div class="audio-row">
-            <span class="audio-label">🎙️ Mic (you→DUT)</span>
-            <div class="audio-bar-bg"><div class="audio-bar-fill" id="localBar"></div></div>
-            <span class="audio-val" id="localVal">0%</span>
+        <div class="p-dialog-content">
+
+            <!-- Waiting state -->
+            <div id="waitCard">
+                <div class="waiting-banner">
+                    ⏳ Waiting for the test to start the WebRTC session…<br>
+                    Keep this page open. Audio and video will appear automatically.
+                </div>
+            </div>
+
+            <!-- Live session (shown once peer connected) -->
+            <div id="mediaCard" style="display:none;">
+                <div class="video-container">
+                    <video id="remoteVideo" autoplay playsinline muted></video>
+                </div>
+
+                <!-- Sound enable banner — browser requires user gesture to play audio -->
+                <div id="soundBanner" class="sound-banner">
+                    🔇 Audio is muted (browser policy). Click to enable sound.
+                    <button class="sound-btn" onclick="enableSound()">Enable Sound</button>
+                </div>
+
+                <div class="state-row">
+                    Peer Connection State: <span id="peerState" class="state-badge state-default">—</span>
+                </div>
+
+                <div class="audio-row">
+                    <span class="audio-label">🔈 Speaker (DUT→you)</span>
+                    <div class="audio-bar-bg"><div class="audio-bar-fill" id="remoteBar"></div></div>
+                    <span class="audio-val" id="remoteVal">0%</span>
+                </div>
+                <div class="audio-row">
+                    <span class="audio-label">🎙️ Mic (you→DUT)</span>
+                    <div class="audio-bar-bg"><div class="audio-bar-fill" id="localBar"></div></div>
+                    <span class="audio-val" id="localVal">0%</span>
+                </div>
+            </div>
+
+            <!-- PASS/FAIL prompt (shown at step 8) -->
+            <div id="actionCard" style="display:none;">
+                <div class="subheader" id="promptText"></div>
+
+                <div class="input-items-div">
+                    <div class="popup-radio-div" id="radioOptions"></div>
+                </div>
+
+                <div class="buttons-div">
+                    <button id="submitBtn" class="popup-button" onclick="submitResponse()" disabled>
+                        Submit
+                    </button>
+                </div>
+            </div>
+
         </div>
     </div>
-
-    <!-- Waiting state (shown before peer connects) -->
-    <div class="card" id="waitCard">
-        <div class="waiting-banner">
-            ⏳ Waiting for the test to start the WebRTC session…<br>
-            Keep this page open. Audio and video will appear automatically.
-        </div>
-    </div>
-
-    <!-- PASS/FAIL prompt (shown when test reaches step 8) -->
-    <div class="card" id="actionCard">
-        <p class="card-title">Verification</p>
-        <p class="prompt-text" id="promptText"></p>
-        <div class="radio-options" id="radioOptions">
-        </div>
-        <button class="submit-btn" id="submitBtn" onclick="submitResponse()" disabled>Submit Response</button>
-    </div>
-
 </div>
 
 
@@ -164,54 +394,58 @@
     let remoteStreams = {{}};    // sessionId -> MediaStream (single stream with all remote tracks)
     let localStream = null;
     let audioCtx = null, localAnalyser = null, remoteAnalyser = null, animId = null;
+    let remoteAudioStream = null;  // kept so analyser can be re-attached after AudioContext resume
     let selectedValue = null;
     let promptReady = {prompt_ready};   // False until server sets prompt; injected server-side
+
+    // ── Sound enable (requires user gesture) ─────────────────────────────────
+    function enableSound() {{
+        const vid = document.getElementById("remoteVideo");
+        vid.muted = false;
+        if (audioCtx) {{
+            audioCtx.resume().then(() => {{
+                // Re-attach remote analyser now that context is running
+                if (remoteAudioStream) {{
+                    remoteAnalyser = null;  // discard stale suspended analyser
+                    attachAnalyser(remoteAudioStream, "remote");
+                }}
+            }});
+        }}
+        document.getElementById("soundBanner").style.display = "none";
+    }}
 
     // ── UI helpers ────────────────────────────────────────────────────────────
     function setPeerState(state) {{
         const el = document.getElementById("peerState");
         el.textContent = state.toUpperCase();
-        el.className = {{
+        el.className = "state-badge " + ({{
             "connected":    "state-connected",
             "connecting":   "state-connecting",
             "failed":       "state-failed",
             "disconnected": "state-failed",
             "closed":       "state-closed",
-        }}[state] || "state-default";
+        }}[state] || "state-default");
         if (state === "connected") {{
             document.getElementById("waitCard").style.display  = "none";
             document.getElementById("mediaCard").style.display = "block";
-            document.getElementById("unmuteBtn").style.display = "inline-block";
             if (promptReady) document.getElementById("actionCard").style.display = "block";
-            // Resume AudioContext now that we have user-context via WebRTC activity
-            if (audioCtx && audioCtx.state === "suspended") audioCtx.resume();
         }}
-    }}
-
-    function unmuteVideo() {{
-        const v = document.getElementById("remoteVideo");
-        v.muted = !v.muted;
-        document.getElementById("unmuteBtn").textContent = v.muted ? "🔊 Unmute" : "🔇 Mute";
-        if (audioCtx && audioCtx.state === "suspended") audioCtx.resume();
     }}
 
     function showPrompt(promptText, options) {{
         promptReady = true;
-        // Populate prompt text
         document.getElementById("promptText").textContent = promptText || "Verify two-way talk";
-        // Render radio buttons dynamically from server data
         const container = document.getElementById("radioOptions");
         container.innerHTML = "";
         for (const [label, value] of Object.entries(options || {{}})) {{
             const div = document.createElement("div");
-            div.className = "radio-row";
+            div.className = "popup-radio-row";
             div.dataset.value = value;
             div.onclick = () => selectOption(value);
             div.innerHTML = `<input type="radio" name="option" value="${{value}}" id="radio_${{value}}">` +
                              `<label for="radio_${{value}}">${{label}}</label>`;
             container.appendChild(div);
         }}
-        // Show actionCard if WebRTC is already connected
         if (document.getElementById("mediaCard").style.display === "block") {{
             document.getElementById("actionCard").style.display = "block";
         }}
@@ -337,6 +571,7 @@
             if (e.track.kind === "audio") {{
                 // Use a separate single-track stream for the analyser only
                 const audioStream = new MediaStream([e.track]);
+                remoteAudioStream = audioStream;  // save for re-attach after AudioContext resume
                 attachAnalyser(audioStream, "remote");
             }}
         }};
@@ -436,15 +671,19 @@
     // ── Prompt PASS/FAIL ──────────────────────────────────────────────────────
     function selectOption(value) {{
         selectedValue = value;
-        document.querySelectorAll(".radio-row").forEach(r => {{
-            r.classList.toggle("selected", parseInt(r.dataset.value)===value);
-            r.querySelector("input").checked = (parseInt(r.dataset.value)===value);
+        document.querySelectorAll(".popup-radio-row").forEach(r => {{
+            r.classList.toggle("selected", parseInt(r.dataset.value) === value);
+            r.querySelector("input").checked = (parseInt(r.dataset.value) === value);
         }});
         document.getElementById("submitBtn").disabled = false;
     }}
 
     function submitResponse() {{
         if (selectedValue === null) return;
+        const btn = document.getElementById("submitBtn");
+        btn.classList.add("submitting");
+        btn.textContent = "Submitting...";
+        btn.disabled = true;
         fetch("/submit_response", {{
             method: "POST",
             headers: {{"Content-Type": "application/json"}},
@@ -452,10 +691,21 @@
         }})
         .then(r => r.json())
         .then(() => {{
-            document.getElementById("submitBtn").disabled = true;
-            document.getElementById("submitBtn").textContent = "✅ Response Submitted";
+            btn.textContent = "Response Sent!";
+            btn.style.background = "#4caf50";
+            setTimeout(() => {{ btn.textContent = "Complete"; }}, 1000);
         }})
-        .catch(e => alert("Failed to submit: "+e));
+        .catch(e => {{
+            console.error("Submit error:", e);
+            btn.textContent = "Error - Try Again";
+            btn.style.background = "#f44336";
+            btn.disabled = false;
+            btn.classList.remove("submitting");
+            setTimeout(() => {{
+                btn.textContent = "Submit";
+                btn.style.background = "";
+            }}, 3000);
+        }});
     }}
 
     // ── Poll server for prompt readiness ──────────────────────────────────────

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -32,6 +32,7 @@ from th_cli.config import config
 from th_cli.shared_constants import MessageKeysEnum, MessageTypeEnum
 
 from .camera.camera_http_server import CameraHTTPServer
+from .camera.two_way_talk_handler import TwoWayTalkHandler
 from .socket_schemas import (
     ImageVerificationPromptRequest,
     MessagePromptRequest,
@@ -68,7 +69,12 @@ def _get_local_ip() -> str:
         return "localhost"
 
 
-async def handle_prompt(socket: WebSocketClientProtocol, request: PromptRequest, message_type: str = None) -> None:
+async def handle_prompt(
+    socket: WebSocketClientProtocol,
+    request: PromptRequest,
+    message_type: str = None,
+    two_way_talk_handler=None,
+) -> None:
     """Handle all types of prompts with correct inheritance order."""
     click.echo("=======================================")
 
@@ -79,7 +85,7 @@ async def handle_prompt(socket: WebSocketClientProtocol, request: PromptRequest,
     elif message_type == MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST or isinstance(
         request, TwoWayTalkVerificationRequest
     ):
-        await _handle_two_way_talk_prompt(socket=socket, prompt=request)
+        await _handle_two_way_talk_prompt(socket=socket, prompt=request, handler=two_way_talk_handler)
     elif message_type == MessageTypeEnum.STREAM_VERIFICATION_REQUEST or isinstance(
         request, StreamVerificationPromptRequest
     ):
@@ -248,16 +254,15 @@ async def _handle_image_verification_prompt(
         click.echo(colorize_error(f"❌ Error handling image verification: {e}"), err=True)
 
 
-async def _handle_two_way_talk_prompt(socket: WebSocketClientProtocol, prompt: OptionsSelectPromptRequest) -> None:
+async def _handle_two_way_talk_prompt(
+    socket: WebSocketClientProtocol, prompt: OptionsSelectPromptRequest, handler=None
+) -> None:
     """Handle two-way talk verification via browser page on port 8999."""
-    from .camera.two_way_talk_handler import TwoWayTalkHandler, get_active_handler
-
-    handler = get_active_handler()
     if handler is None:
-        # Handler reference lost. Do NOT call start_waiting() — it runs fuser -k
+        # Handler not injected. Do NOT call start_waiting() — it runs fuser -k
         # which would kill this process (which holds port 8999).
         # Create a fresh server on the same port without freeing it first.
-        click.echo("WARNING: TwoWayTalk handler reference lost — creating fallback server", err=True)
+        click.echo("WARNING: TwoWayTalk handler not available — creating fallback server", err=True)
         handler = TwoWayTalkHandler(port=8999)
         try:
             handler.start_server_only()

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -250,7 +250,7 @@ async def _handle_image_verification_prompt(
 
 async def _handle_two_way_talk_prompt(socket: WebSocketClientProtocol, prompt: OptionsSelectPromptRequest) -> None:
     """Handle two-way talk verification via browser page on port 8999."""
-    from .camera.two_way_talk_handler import get_active_handler, TwoWayTalkHandler
+    from .camera.two_way_talk_handler import TwoWayTalkHandler, get_active_handler
 
     handler = get_active_handler()
     if handler is None:

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -253,7 +253,6 @@ async def _handle_two_way_talk_prompt(socket: WebSocketClientProtocol, prompt: O
     from .camera.two_way_talk_handler import get_active_handler, TwoWayTalkHandler
 
     handler = get_active_handler()
-    click.echo(f"DEBUG TwoWayTalk: handler={handler!r}", err=True)
     if handler is None:
         # Handler reference lost. Do NOT call start_waiting() — it runs fuser -k
         # which would kill this process (which holds port 8999).

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -41,6 +41,7 @@ from .socket_schemas import (
     PushAVStreamVerificationRequest,
     StreamVerificationPromptRequest,
     TextInputPromptRequest,
+    TwoWayTalkVerificationRequest,
     UserResponseStatusEnum,
 )
 
@@ -75,6 +76,10 @@ async def handle_prompt(socket: WebSocketClientProtocol, request: PromptRequest,
         request, ImageVerificationPromptRequest
     ):
         await _handle_image_verification_prompt(socket=socket, prompt=request)
+    elif message_type == MessageTypeEnum.TWO_WAY_TALK_VERIFICATION_REQUEST or isinstance(
+        request, TwoWayTalkVerificationRequest
+    ):
+        await _handle_two_way_talk_prompt(socket=socket, prompt=request)
     elif message_type == MessageTypeEnum.STREAM_VERIFICATION_REQUEST or isinstance(
         request, StreamVerificationPromptRequest
     ):
@@ -241,6 +246,41 @@ async def _handle_image_verification_prompt(
 
     except Exception as e:
         click.echo(colorize_error(f"❌ Error handling image verification: {e}"), err=True)
+
+
+async def _handle_two_way_talk_prompt(socket: WebSocketClientProtocol, prompt: OptionsSelectPromptRequest) -> None:
+    """Handle two-way talk verification via browser page on port 8999."""
+    from .camera.two_way_talk_handler import get_active_handler, TwoWayTalkHandler
+
+    handler = get_active_handler()
+    click.echo(f"DEBUG TwoWayTalk: handler={handler!r}", err=True)
+    if handler is None:
+        # Handler reference lost. Do NOT call start_waiting() — it runs fuser -k
+        # which would kill this process (which holds port 8999).
+        # Create a fresh server on the same port without freeing it first.
+        click.echo("WARNING: TwoWayTalk handler reference lost — creating fallback server", err=True)
+        handler = TwoWayTalkHandler(port=8999)
+        try:
+            handler.start_server_only()
+        except OSError as e:
+            click.echo(colorize_error(f"Could not start fallback server: {e}"), err=True)
+
+    handler.show_prompt(prompt_text=prompt.prompt, prompt_options=prompt.options)
+    local_ip = _get_local_ip()
+    try:
+        click.echo("🎤 Two-Way Talk Verification")
+        click.echo(italic(prompt.prompt))
+        click.echo(f"   Open http://{local_ip}:8999 to verify audio/video and select PASS or FAIL.")
+        click.echo("   Waiting for your response in the browser...")
+        user_answer = await handler.wait_for_user_response(float(prompt.timeout))
+        if user_answer is None:
+            click.echo(colorize_error("Two-way talk prompt timed out"), err=True)
+            return
+        selected_option = next((k for k, v in prompt.options.items() if v == user_answer), str(user_answer))
+        click.echo(f"✅ User selected: {selected_option}")
+        await _send_prompt_response(socket=socket, response=user_answer, prompt=prompt)
+    finally:
+        handler.stop()
 
 
 async def _handle_push_av_stream_prompt(

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -32,6 +32,7 @@ from th_cli.config import config
 from th_cli.shared_constants import MessageKeysEnum, MessageTypeEnum
 
 from .camera.camera_http_server import CameraHTTPServer
+from .camera.image_handler import ImageVerificationHandler
 from .camera.two_way_talk_handler import TwoWayTalkHandler
 from .socket_schemas import (
     ImageVerificationPromptRequest,
@@ -210,8 +211,6 @@ async def _handle_image_verification_prompt(
         image_data = bytes.fromhex(image_hex_clean)
 
         # Use existing ImageVerificationHandler
-        from .camera.image_handler import ImageVerificationHandler
-
         image_handler = ImageVerificationHandler()
         image_handler.set_prompt_data(prompt.prompt, prompt.options, image_data)
 

--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -237,7 +237,7 @@ class TestRunSocket:
                 logger.debug(f"No tracked step errors found for test case {case_key}")
 
             # Check if a WebRTC test failed because the browser peer connection was unavailable.
-            # TC_WEBRTC_1_6 uses the TH browser tab as a WebRTC client — the browser must be
+            # Two-way talk tests uses the TH browser tab as a WebRTC client — the browser must be
             # open with the TH UI for the test to work.
             if all_errors:
                 error_text = " ".join(all_errors).lower()

--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -58,9 +58,15 @@ WEBSOCKET_MAX_MESSAGE_SIZE = 32 * 1024 * 1024  # 32MB
 
 
 class TestRunSocket:
-    def __init__(self, run: TestRunExecutionWithChildren, project_config_dict: dict | None = None):
+    def __init__(
+        self,
+        run: TestRunExecutionWithChildren,
+        project_config_dict: dict | None = None,
+        two_way_talk_handler=None,
+    ):
         self.run = run
         self.project_config_dict = project_config_dict or {}
+        self.two_way_talk_handler = two_way_talk_handler
         self._chip_server_info_displayed = False
         # Track test step errors for logging
         # Key: (suite_index, case_index), Value: list of error strings from all steps
@@ -116,7 +122,12 @@ class TestRunSocket:
                 await handle_file_upload_request(socket=socket, request=message.payload)
             else:
                 # Pass both the request and the message type to handle_prompt
-                await handle_prompt(socket=socket, request=message.payload, message_type=message.type)
+                await handle_prompt(
+                    socket=socket,
+                    request=message.payload,
+                    message_type=message.type,
+                    two_way_talk_handler=self.two_way_talk_handler,
+                )
         elif message.type == MessageTypeEnum.TEST_LOG_RECORDS and isinstance(message.payload, list):
             self.__handle_log_record(message.payload)
         elif isinstance(message.payload, TimeOutNotification):

--- a/th_cli/test_run/websocket.py
+++ b/th_cli/test_run/websocket.py
@@ -54,14 +54,6 @@ from .socket_schemas import (
 
 WEBSOCKET_URL = f"ws://{config.hostname}/api/v1/ws"
 
-webrtc_indicators = [
-    "browserpeerconnection",
-    "webrtc",
-    "browser peer",
-    "ws://backend/api/v1/ws/webrtc",
-    "create_browser_peer",
-]
-
 WEBSOCKET_MAX_MESSAGE_SIZE = 32 * 1024 * 1024  # 32MB
 
 
@@ -70,7 +62,7 @@ class TestRunSocket:
         self.run = run
         self.project_config_dict = project_config_dict or {}
         self._chip_server_info_displayed = False
-        # Track test step errors for WebRTC detection
+        # Track test step errors for logging
         # Key: (suite_index, case_index), Value: list of error strings from all steps
         self.test_case_step_errors: dict[tuple[int, int], list[str]] = {}
 
@@ -224,8 +216,7 @@ class TestRunSocket:
         colored_state = colorize_state(update.state.value)
         click.echo(f"      - {colored_title} {colored_state}")
 
-        # Check if test failed/errored due to WebRTC/browser requirements
-        # Collect errors from both the test case update and tracked step errors
+        # Log any errors when a test case fails
         if update.state.value in ("failed", "error"):
             all_errors = []
 
@@ -245,23 +236,18 @@ class TestRunSocket:
             else:
                 logger.debug(f"No tracked step errors found for test case {case_key}")
 
-            # Fallback: Check if this is a known WebRTC test by public_id
-            is_webrtc_test = public_id in {"TC_WEBRTC_1_6"}
-
+            # Check if a WebRTC test failed because the browser peer connection was unavailable.
+            # TC_WEBRTC_1_6 uses the TH browser tab as a WebRTC client — the browser must be
+            # open with the TH UI for the test to work.
             if all_errors:
                 error_text = " ".join(all_errors).lower()
-                logger.debug(f"Checking error text for WebRTC indicators: {error_text[:200]}")
-                # Check for common WebRTC/browser-related error indicators
-                if any(indicator in error_text for indicator in webrtc_indicators):
-                    is_webrtc_test = True
-
-            # Display warning if this is a WebRTC test
-            if is_webrtc_test:
-                click.echo("")
-                click.echo(colorize_error("⚠️  TWO-WAY TALK TEST NOT SUPPORTED IN CLI"), err=True)
-                click.echo(colorize_error(f"   {title} requires a browser WebRTC implementation."), err=True)
-                click.echo(colorize_error("   This test cannot run from the CLI. Please use the Web UI."), err=True)
-                click.echo("")
+                browser_peer_errors = ["peer not found", "browserpeerconnection", "create_browser_peer"]
+                if any(indicator in error_text for indicator in browser_peer_errors):
+                    click.echo("")
+                    click.echo(colorize_error("⚠️  BROWSER TAB REQUIRED"), err=True)
+                    click.echo(colorize_error(f"   {title} requires the TH browser UI to be open."), err=True)
+                    click.echo(colorize_error("   Open the TH web interface in a browser tab and re-run."), err=True)
+                    click.echo("")
             elif not all_errors:
                 logger.debug(f"Test case {public_id} ({case_key}) failed but has no error messages")
 


### PR DESCRIPTION
### What Changed
This PR adds the Two-Way Talk support. - 

TC-WEBRTC-1.6 Two-Way Talk support: New two_way_talk_handler.py starts an HTTP server on port 8999 serving a WebRTC browser peer page (two_way_talk_verification.html). The CLI now waits until the browser is detected as open before resuming test execution, and the prompt manager renders the PASS/FAIL form dynamically via /prompt_ready polling.

###  Related Issue
https://github.com/project-chip/certification-tool/issues/904

### Testing
New Unit test added and passing

CLI execution runs successfully. CLI command: `th-cli run-tests -t TC_WEBRTC_1_6  --project-id 4`
chip-camera-app command:  `rm -rf /tmp/chip_*;./chip-camera-app --camera-test-audiosrc --camera-audio-playback`

> ubuntu@ubuntu:~/certification-tool/cli$ th-cli run-tests -t TC_WEBRTC_1_6  --project-id 4
> Project Config: {'test_parameters': {'endpoint': 1}, 'network': {'wifi': {'ssid': 'testharness', 'password': 'wifi-password'}, 'thread': {'rcp_serial_path': '/dev/ttyACM0', 'rcp_baudrate': 115200, 'on_mesh_prefix': 'fd11:22::/64', 'network_interface': 'eth0', 'dataset': {'channel': '15', 'panid': '0x1234', 'extpanid': '1111111122222222', 'networkkey': '00112233445566778899aabbccddeeff', 'networkname': 'DEMO'}, 'otbr_docker_image': None, 'ba_host': '127.0.0.1', 'ba_port': 5684}}, 'dut_config': {'discriminator': '3840', 'setup_code': '20202021', 'pairing_mode': 'onnetwork', 'chip_timeout': None, 'chip_use_paa_certs': False, 'trace_log': True, 'enhanced_setup_flow': None}}
> PICS Used: {
>   "clusters": {}
> }
> Selected tests: {
>   "SDK Python Tests": {
>     "Python Testing Suite": {
>       "TC_WEBRTC_1_6": 1
>     }
>   }
> }
> Creating new test run with title: 2026-03-13-12:29:34
> ═════════════════════════════════════════════════════════
>   ⚠  WebRTC Two-Way Talk — Action Required  ⚠
> ═════════════════════════════════════════════════════════
>   Open this URL in a browser NOW and keep it open:
>   http://192.168.20.180:8999
>   The page will connect to the DUT automatically.
>   You will be asked to select PASS or FAIL during the test.
> ═════════════════════════════════════════════════════════
> 
>   Waiting for browser to open the page...
>   ✔ Browser connected — starting test.
> 
> 
> Starting Test run:
> - Title: 2026-03-13-12:29:34
> - ID: 150
> 
> ═══════════════════════════════════════════════════════
> CHIP Server Information:
> - Node ID: 0xda8fab5116165dad
> - Manual Pairing Code: 34970112332
> ═══════════════════════════════════════════════════════
> 
> Test Run [EXECUTING]
>   - Python Testing Suite [EXECUTING]
> =======================================
> Do you want to reuse the previous commissioning information?
> If you select NO, a new commissioning will be performed
>   1: YES
>   2: NO
> Please enter a number for an option above: 
> 2
> =======================================
> =======================================
> Make sure the DUT is in Commissioning Mode
>   1: DONE
>   2: FAILED
> Please enter a number for an option above: 
> 1
> =======================================
>       - TC-WEBRTC-1.6 [EXECUTING]
>             - Start Python test [EXECUTING]
>             - Start Python test [PASSED]
>             - Commission DUT if not already done [EXECUTING]
>             - Commission DUT if not already done [PASSED]
>             - Confirm no active WebRTC sessions exist in DUT [EXECUTING]
>             - Confirm no active WebRTC sessions exist in DUT [PASSED]
>             - Confirm DUT(Camera) supports Speaker feature AVSM.S.F04(SPKR) [EXECUTING]
>             - Confirm DUT(Camera) supports Speaker feature AVSM.S.F04(SPKR) [PASSED]
>             - TH reads TwoWayTalkSupport Attribute from AVSM cluster from DUT [EXECUTING]
>             - TH reads TwoWayTalkSupport Attribute from AVSM cluster from DUT [PASSED]
>             - If DUT supports AVSM.S.F01(VDO) feature, TH sends the VideoStreamAllocate command with valid values of StreamUsage, VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate, MinFrameRate, MaxFrameRate, KeyFrameInterval, WatermarkEnabled, OSDEnabled [EXECUTING]
>             - If DUT supports AVSM.S.F01(VDO) feature, TH sends the VideoStreamAllocate command with valid values of StreamUsage, VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate, MinFrameRate, MaxFrameRate, KeyFrameInterval, WatermarkEnabled, OSDEnabled [PASSED]
>             - TH sends the AudioStreamAllocate command with valid values of StreamUsage, AudioCodec, ChannelCount, SampleRate, BitDepth, BitRate. [EXECUTING]
>             - TH sends the AudioStreamAllocate command with valid values of StreamUsage, AudioCodec, ChannelCount, SampleRate, BitDepth, BitRate. [PASSED]
>             - TH sends the ProvideOffer command with an SDP Offer, null WebRTCSessionID, VideoStreamID and AudioStreamID saved in steps 2, 3 to the DUT. [EXECUTING]
>             - TH sends the ProvideOffer command with an SDP Offer, null WebRTCSessionID, VideoStreamID and AudioStreamID saved in steps 2, 3 to the DUT. [PASSED]
>             - DUT sends Answer command to the TH/WEBRTCR. [EXECUTING]
>             - DUT sends Answer command to the TH/WEBRTCR. [PASSED]
>             - TH sends the SUCCESS status code to the DUT. [EXECUTING]
>             - TH sends the SUCCESS status code to the DUT. [PASSED]
>             - TH sends the ProvideICECandidates command with a its ICE candidates to the DUT. [EXECUTING]
>             - TH sends the ProvideICECandidates command with a its ICE candidates to the DUT. [PASSED]
>             - TH waits for 10 seconds [EXECUTING]
> =======================================
> 🎤 Two-Way Talk Verification
> Verify if two way talk back is working
>    Open http://192.168.20.180:8999 to verify audio/video and select PASS or FAIL.
>    Waiting for your response in the browser...
> ✅ User selected: PASS
> =======================================
>             - TH waits for 10 seconds [PASSED]
>             - TH sends the EndSession command with the WebRTCSessionID saved in step 4 to the DUT. [EXECUTING]
>             - TH sends the EndSession command with the WebRTCSessionID saved in step 4 to the DUT. [PASSED]
>             - TH sends the VideoStreamDeallocate command if allocated, with the VideoStreamID saved in step 2 to the DUT. [EXECUTING]
>             - TH sends the VideoStreamDeallocate command if allocated, with the VideoStreamID saved in step 2 to the DUT. [PASSED]
>             - TH sends the AudioStreamDeallocate command with the AudioStreamID saved in step 3 to the DUT. [EXECUTING]
>             - TH sends the AudioStreamDeallocate command with the AudioStreamID saved in step 3 to the DUT. [PASSED]
>             - Show test logs [EXECUTING]
>             - Show test logs [PASSED]
>       - TC-WEBRTC-1.6 [PASSED]
>   - Python Testing Suite [PASSED]
> Test Run [PASSED]
> Log output in: ./output_logs/test_run_2026-03-13-12:29:34.log
