### PR TITLE
Update regex to support TC-I-XXX tests in CLI - Propagate fix from v2.15

### DIFF
--- a/th_cli/validation.py
+++ b/th_cli/validation.py
@@ -96,7 +96,7 @@ def validate_test_ids(test_ids: str) -> list[str]:
         raise CLIError("No valid test IDs provided")
 
     # Validate each test ID format
-    valid_pattern = re.compile(r"^TC[-_][A-Z_]{2,20}([-_\.]\d+){2,3}(-custom)?$")
+    valid_pattern = re.compile(r"^TC[-_][A-Z0-9][A-Z0-9_]{0,19}?([-_\.]\d+){1,3}(-custom)?$")
 
     invalid_ids = []
     for test_id in ids:


### PR DESCRIPTION
### What changed 
The goal of this PR is to propagate the changes for v2.15 in to v2.14.1

### Related Issue
https://github.com/project-chip/certification-tool/issues/873

### Testing
Tested the following command in CLI:
th-cli run-tests -t TC-WEBRTCP-2.1 --project-id 2
th-cli run-tests -t TC_I_3_2 --project-id 2
th-cli run-tests -t TC_I_3 --project-id 2
th-cli run-tests -t TC_BR_3 --project-id 2