### PR TITLE
[Feature] Add PICS Parameter To CLI Projects

### DIFF
--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -455,7 +455,7 @@ class TestUpdateProjectCommand:
 
         # Assert
         assert result.exit_code == 0
-        assert "Project Test Project is updated with the new config." in result.output
+        assert "Project 'Test Project' was updated." in result.output
         mock_sync_apis.projects_api.update_project_api_v1_projects__id__put.assert_called_once()
 
     def test_update_project_config_file_not_found(

--- a/th_cli/commands/project.py
+++ b/th_cli/commands/project.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 
 from th_cli.api_lib_autogen.api_client import SyncApis
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
-from th_cli.api_lib_autogen.models import Project, ProjectCreate, ProjectUpdate
+from th_cli.api_lib_autogen.models import PICS, Project, ProjectCreate, ProjectUpdate
 from th_cli.client import get_client
 from th_cli.colorize import (
     colorize_cmd_help,
@@ -34,7 +34,8 @@ from th_cli.colorize import (
     italic,
 )
 from th_cli.exceptions import CLIError, handle_api_error, handle_file_error
-from th_cli.utils import __print_json
+from th_cli.utils import __print_json, read_pics_config
+from th_cli.validation import validate_directory_path
 
 TABLE_FORMAT = "{:<5} {:25} {:28}"
 
@@ -82,10 +83,16 @@ def get_sync_apis(operation: str):
     type=click.Path(file_okay=True, dir_okay=False),
     help=colorize_help("Config JSON file for the project"),
 )
-def create(name: str, config: str | None) -> None:
+@click.option(
+    "--pics-config-folder",
+    "-p",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help=colorize_help("Directory containing PICS XML configuration files"),
+)
+def create(name: str, config: str | None, pics_config_folder: str | None) -> None:
     """Create a new project"""
     with get_sync_apis("create") as sync_apis:
-        _create_project(sync_apis, name, config)
+        _create_project(sync_apis, name, config, pics_config_folder)
 
 
 # Click command to list projects
@@ -159,10 +166,16 @@ def list_projects(
     type=click.Path(file_okay=True, dir_okay=False),
     help=colorize_help("Config JSON file for the project"),
 )
-def update(id: int, config: str | None, name: str | None) -> None:
+@click.option(
+    "--pics-config-folder",
+    "-p",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help=colorize_help("Directory containing PICS XML configuration files"),
+)
+def update(id: int, config: str | None, name: str | None, pics_config_folder: str | None) -> None:
     """Update an existing project"""
     with get_sync_apis("update") as sync_apis:
-        _update_project(sync_apis, id, name, config)
+        _update_project(sync_apis, id, name, config, pics_config_folder)
 
 
 # Click command to delete an existing project
@@ -194,7 +207,7 @@ def delete(id: int, yes: bool) -> None:
         _delete_project(sync_apis, id)
 
 
-def _create_project(sync_apis: SyncApis, name: str, config: str | None) -> None:
+def _create_project(sync_apis: SyncApis, name: str, config: str | None, pics_config_folder: str | None) -> None:
     """Create a new project"""
     # Get default config
     try:
@@ -215,8 +228,17 @@ def _create_project(sync_apis: SyncApis, name: str, config: str | None) -> None:
         except ValidationError as e:
             raise CLIError(f"Invalid configuration: {e}")
 
+    # Process PICS configuration if provided
+    pics = None
+    if pics_config_folder:
+        pics_path = validate_directory_path(pics_config_folder, must_exist=True)
+        pics_dict = read_pics_config(str(pics_path))
+        # Convert dict to PICS model
+        pics = PICS.model_validate(pics_dict)
+        click.echo(colorize_success(f"Loaded PICS configuration from '{pics_config_folder}'"))
+
     # Create project
-    project_create = ProjectCreate(name=name, config=test_environment_config)
+    project_create = ProjectCreate(name=name, config=test_environment_config, pics=pics)
 
     try:
         response = sync_apis.projects_api.create_project_api_v1_projects__post(body=project_create)
@@ -288,28 +310,47 @@ def _update_project(
     id: int,
     name: str | None = None,
     config_path: str | None = None,
+    pics_config_folder: str | None = None,
 ) -> None:
     """Update an existing project"""
     try:
-        if all(param is None for param in [name, config_path]):
+        if all(param is None for param in [name, config_path, pics_config_folder]):
             click.echo(colorize_warning("Nothing to be done. Please provide at least one parameter to update."))
             return
 
         # Get existing project to preserve its name and other fields
         existing_project = sync_apis.projects_api.read_project_api_v1_projects__id__get(id=id)
 
-        # Load the new config
-        with open(config_path, "r") as f:
-            config_dict = json.load(f)
+        # Use the new name, if provided
+        project_name = existing_project.name
+        if name:
+            project_name = name
+            click.echo(colorize_success(f"Project will be renamed to '{project_name}'"))
+
+        # Load the new config if provided
+        config_dict = existing_project.config
+        if config_path:
+            with open(config_path, "r") as f:
+                config_dict = json.load(f)
+                click.echo(colorize_success(f"Loaded project configuration from '{config_path}'"))
+
+        # Process PICS configuration if provided
+        pics = existing_project.pics
+        if pics_config_folder:
+            pics_path = validate_directory_path(pics_config_folder, must_exist=True)
+            pics_dict = read_pics_config(str(pics_path))
+            # Convert dict to PICS model
+            pics = PICS.model_validate(pics_dict)
+            click.echo(colorize_success(f"Loaded PICS configuration from '{pics_config_folder}'"))
 
         project_update = ProjectUpdate(
-            name=name if name is not None else existing_project.name,
-            config=config_dict if config_dict is not None else existing_project.config,
-            pics=existing_project.pics,
+            name=project_name,
+            config=config_dict,
+            pics=pics,
         )
 
         response = sync_apis.projects_api.update_project_api_v1_projects__id__put(id=id, body=project_update)
-        click.echo(colorize_success(f"Project {response.name} is updated with the new config."))
+        click.echo(colorize_success(f"Project '{response.name}' was updated."))
     except json.JSONDecodeError as e:
         raise CLIError(f"Failed to parse JSON parameter: {e.msg}")
     except FileNotFoundError as e:

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -34,6 +34,7 @@ from th_cli.colorize import (
     colorize_header,
     colorize_help,
     colorize_key_value,
+    colorize_warning,
     italic,
     set_colors_enabled,
 )
@@ -175,8 +176,12 @@ async def run_tests(
                 test_run_config["test_parameters"] = {}
             test_run_config["test_parameters"].update(extra_test_params)
 
-        # Read PICS configuration if provided
-        pics = read_pics_config(pics_config_folder)
+        # Read PICS configuration if provided via CLI, otherwise get from project
+        pics: dict[str, Any] = {"clusters": {}}
+        if pics_config_folder:
+            pics = read_pics_config(pics_config_folder)
+        else:
+            pics = await _get_project_pics(async_apis, project_id)
         click.echo(colorize_key_value("PICS Used", json.dumps(pics, indent=JSON_INDENT)))
 
         # Retrieve available test collections to build test selection
@@ -235,15 +240,45 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
     if project_id is not None:
         try:
             project = await projects_api.read_project_api_v1_projects__id__get(id=project_id)
-            return project.config
+            if project.config:
+                return project.config
         except UnexpectedResponse as e:
             msg = (
                 f"Could not retrieve configuration for project ID '{project_id}': {e}"
                 "Falling back to default configuration."
             )
-            click.echo(colorize_key_value("Warning:", msg))
+            click.echo(colorize_warning(f"Warning: {msg}"))
 
     return await projects_api.default_config_api_v1_projects_default_config_get()
+
+
+async def _get_project_pics(async_apis: AsyncApis, project_id: int | None = None) -> dict[str, Any]:
+    """Retrieve project PICS for given project ID.
+
+    Args:
+        async_apis: AsyncApis instance for making API calls
+        project_id: Optional project ID to retrieve PICS from
+
+    Returns:
+        Dictionary containing project PICS, or empty PICS dict if no project or PICS found
+
+    Raises:
+        May raise API-related exceptions if project retrieval fails
+    """
+    # Return empty PICS if no project_id is provided
+    if project_id is None:
+        return {"clusters": {}}
+
+    projects_api = async_apis.projects_api
+
+    try:
+        project = await projects_api.read_project_api_v1_projects__id__get(id=project_id)
+        # Convert PICS model to dict if it exists, otherwise return empty PICS
+        if project.pics:
+            return convert_nested_to_dict(project.pics)
+    except UnexpectedResponse as e:
+        click.echo(colorize_warning(f"Warning: Could not retrieve PICS for project ID '{project_id}': {e}"))
+    return {"clusters": {}}
 
 
 def _contains_webrtc_two_way_talk(selected_tests: dict[str, Any]) -> bool:

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -42,7 +42,7 @@ from th_cli.config import config as th_config
 from th_cli.exceptions import CLIError, handle_api_error
 from th_cli.test_run.camera.two_way_talk_handler import TwoWayTalkHandler
 from th_cli.test_run.websocket import TestRunSocket
-from th_cli.utils import build_test_selection, convert_nested_to_dict, load_json_config, merge_configs, read_pics_config
+from th_cli.utils import DEFAULT_CLI_PROJECT_NAME, build_test_selection, convert_nested_to_dict, load_json_config, merge_configs, read_pics_config
 from th_cli.validation import validate_directory_path, validate_file_path, validate_test_ids
 
 # Constants
@@ -150,6 +150,11 @@ async def run_tests(
         # Configure new log output for test.
         log_path = test_logging.configure_logger_for_run(title=title)
 
+        # Retrieve CLI default project ID if not provided
+        if project_id is None:
+            project_id = await _get_cli_default_project_id(async_apis)
+        click.echo(colorize_key_value("Using CLI Project", f"ID: {project_id}, Name: '{DEFAULT_CLI_PROJECT_NAME}'"))
+
         # Get project config and convert to dict
         project_config = await _get_project_config(async_apis, project_id)
         project_config_dict = convert_nested_to_dict(project_config)
@@ -220,6 +225,32 @@ async def run_tests(
             await client.aclose()
         if _webrtc_handler:
             _webrtc_handler.stop()
+
+
+async def _get_cli_default_project_id(async_apis: AsyncApis) -> int | None:
+    """Retrieve the CLI project ID by searching for the project with DEFAULT_CLI_PROJECT_NAME.
+
+    Args:
+        async_apis: AsyncApis instance for making API calls
+
+    Returns:
+        Project ID if found, otherwise None
+
+    Raises:
+        May raise API-related exceptions if project retrieval fails
+    """
+    projects_api = async_apis.projects_api
+
+    try:
+        # Get all projects and search for the CLI project by name
+        projects = await projects_api.read_projects_api_v1_projects__get(skip=0, limit=None)
+        for project in projects:
+            if project.name == DEFAULT_CLI_PROJECT_NAME:
+                return project.id
+    except UnexpectedResponse as e:
+        click.echo(colorize_warning(f"Warning: Could not retrieve CLI project: {e}"))
+
+    return None
 
 
 async def _get_project_config(async_apis: AsyncApis, project_id: int | None = None) -> dict[str, Any]:

--- a/th_cli/commands/run_tests.py
+++ b/th_cli/commands/run_tests.py
@@ -150,13 +150,11 @@ async def run_tests(
         # Configure new log output for test.
         log_path = test_logging.configure_logger_for_run(title=title)
 
-        # Retrieve CLI default project ID if not provided
-        if project_id is None:
-            project_id = await _get_cli_default_project_id(async_apis)
-        click.echo(colorize_key_value("Using CLI Project", f"ID: {project_id}, Name: '{DEFAULT_CLI_PROJECT_NAME}'"))
+        # Retrieve CLI project
+        cli_project = await _get_cli_project(async_apis, project_id)
 
         # Get project config and convert to dict
-        project_config = await _get_project_config(async_apis, project_id)
+        project_config = await _get_project_config(async_apis, cli_project)
         project_config_dict = convert_nested_to_dict(project_config)
         click.echo(colorize_key_value("Project Config", project_config_dict))
 
@@ -186,7 +184,7 @@ async def run_tests(
         if pics_config_folder:
             pics = read_pics_config(pics_config_folder)
         else:
-            pics = await _get_project_pics(async_apis, project_id)
+            pics = await _get_project_pics(cli_project)
         click.echo(colorize_key_value("PICS Used", json.dumps(pics, indent=JSON_INDENT)))
 
         # Retrieve available test collections to build test selection
@@ -227,38 +225,42 @@ async def run_tests(
             _webrtc_handler.stop()
 
 
-async def _get_cli_default_project_id(async_apis: AsyncApis) -> int | None:
-    """Retrieve the CLI project ID by searching for the project with DEFAULT_CLI_PROJECT_NAME.
-
+async def _get_cli_project(async_apis: AsyncApis, project_id: int | None = None) -> m.Project:
+    """Retrieve the project to use for the CLI test run execution.
     Args:
         async_apis: AsyncApis instance for making API calls
-
+        project_id: Optional project ID to retrieve. If None, retrieves the default CLI project.
     Returns:
-        Project ID if found, otherwise None
-
+        Project object to use for the test run execution
     Raises:
-        May raise API-related exceptions if project retrieval fails
+        CLIError: If the specified project ID does not exist or if the default CLI project cannot be found
     """
     projects_api = async_apis.projects_api
 
+    if project_id is not None:
+        try:
+            return await projects_api.read_project_api_v1_projects__id__get(id=project_id)
+        except UnexpectedResponse as e:
+            raise CLIError(f"Could not retrieve project with ID '{project_id}': {e}")
+
+    # If no project ID provided, search for the default CLI project by name
     try:
-        # Get all projects and search for the CLI project by name
         projects = await projects_api.read_projects_api_v1_projects__get(skip=0, limit=None)
         for project in projects:
             if project.name == DEFAULT_CLI_PROJECT_NAME:
-                return project.id
+                return project
     except UnexpectedResponse as e:
-        click.echo(colorize_warning(f"Warning: Could not retrieve CLI project: {e}"))
+        click.echo(colorize_warning(f"Warning: Could not retrieve CLI default project: {e}"))
 
     return None
 
 
-async def _get_project_config(async_apis: AsyncApis, project_id: int | None = None) -> dict[str, Any]:
+async def _get_project_config(async_apis: AsyncApis, cli_project: m.Project | None = None) -> dict[str, Any]:
     """Retrieve project configuration for given project ID or default configuration.
 
     Args:
         async_apis: AsyncApis instance for making API calls
-        project_id: Optional project ID to retrieve configuration from
+        cli_project: Optional CLI project object to retrieve the project configuration
 
     Returns:
         Dictionary containing project configuration
@@ -266,29 +268,26 @@ async def _get_project_config(async_apis: AsyncApis, project_id: int | None = No
     Raises:
         May raise API-related exceptions if default config retrieval fails
     """
+    try:
+        if cli_project is not None and cli_project.config is not None:
+            return cli_project.config
+    except UnexpectedResponse as e:
+        msg = (
+            f"Could not retrieve configuration for project ID '{cli_project.id}': {e}"
+            "Falling back to default configuration."
+        )
+        click.echo(colorize_warning(f"Warning: {msg}"))
+
     projects_api = async_apis.projects_api
-
-    if project_id is not None:
-        try:
-            project = await projects_api.read_project_api_v1_projects__id__get(id=project_id)
-            if project.config:
-                return project.config
-        except UnexpectedResponse as e:
-            msg = (
-                f"Could not retrieve configuration for project ID '{project_id}': {e}"
-                "Falling back to default configuration."
-            )
-            click.echo(colorize_warning(f"Warning: {msg}"))
-
     return await projects_api.default_config_api_v1_projects_default_config_get()
 
 
-async def _get_project_pics(async_apis: AsyncApis, project_id: int | None = None) -> dict[str, Any]:
+async def _get_project_pics(cli_project: m.Project | None = None) -> dict[str, Any]:
     """Retrieve project PICS for given project ID.
 
     Args:
         async_apis: AsyncApis instance for making API calls
-        project_id: Optional project ID to retrieve PICS from
+        cli_project: Optional CLI project object to retrieve PICS from
 
     Returns:
         Dictionary containing project PICS, or empty PICS dict if no project or PICS found
@@ -296,19 +295,12 @@ async def _get_project_pics(async_apis: AsyncApis, project_id: int | None = None
     Raises:
         May raise API-related exceptions if project retrieval fails
     """
-    # Return empty PICS if no project_id is provided
-    if project_id is None:
-        return {"clusters": {}}
-
-    projects_api = async_apis.projects_api
-
     try:
-        project = await projects_api.read_project_api_v1_projects__id__get(id=project_id)
         # Convert PICS model to dict if it exists, otherwise return empty PICS
-        if project.pics:
-            return convert_nested_to_dict(project.pics)
+        if cli_project is not None and cli_project.pics is not None:
+            return convert_nested_to_dict(cli_project.pics)
     except UnexpectedResponse as e:
-        click.echo(colorize_warning(f"Warning: Could not retrieve PICS for project ID '{project_id}': {e}"))
+        click.echo(colorize_warning(f"Warning: Could not retrieve PICS for project ID '{cli_project.id}': {e}"))
     return {"clusters": {}}
 
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -32,6 +32,7 @@ from th_cli.exceptions import CLIError, handle_file_error
 
 # Constants
 DEFAULT_FILE_ENCODING = "utf-8"
+DEFAULT_CLI_PROJECT_NAME = "CLI Project Execution"
 
 
 def __print_json(object: Any) -> None:


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/898
---

### Description
This PR implements PICS (Protocol Implementation Conformance Statement) configuration handling for the `project create` and `project update` CLI commands, enabling persistent storage of PICS XML configurations at the project level.

### Motivation
Currently, PICS configurations can only be provided temporarily during test execution via the `run-tests --pics-config-folder` command. This meant:
- PICS had to be specified for every test run
- No way to persist PICS as part of a project configuration
- Inconsistent approach between project management and test execution

This implementation addresses the intentionally postponed PICS parameter handling in project commands, allowing users to define PICS once at the project level and reuse them across multiple test runs.

### Changes

#### Implementation Details

**Project Create**:
```python
@click.option(
    "--pics-config-folder",
    "-p",
    type=click.Path(file_okay=False, dir_okay=True),
    help=colorize_help("Directory containing PICS XML configuration files"),
)
def create(name: str, config: str | None, pics_config_folder: str | None) -> None:
    # Processes XML files and converts to PICS model
    # Persists to project via ProjectCreate
```

**Project Update**:
```python
@click.option(
    "--pics-config-folder",
    "-p",
    type=click.Path(file_okay=False, dir_okay=True),
    help=colorize_help("Directory containing PICS XML configuration files"),
)
def update(id: int, config: str | None, name: str | None, pics_config_folder: str | None) -> None:
    # Updates project PICS or preserves existing if not provided
    # Persists to project via ProjectUpdate
```

#### Key Features
1. **XML Processing**: Reuses existing `read_pics_config()` function that:
   - Reads all `.xml` files from the specified directory
   - Parses each file using `parse_pics_xml()`
   - Merges cluster configurations into a single PICS structure

2. **Model Validation**: Converts dictionary to typed `PICS` model using `PICS.model_validate()`

3. **Persistence**: PICS are stored with the project and available for all associated test runs

4. **Backward Compatibility**: 
   - PICS parameter is optional for both commands
   - Existing projects without PICS continue to work
   - Update command preserves existing PICS if not explicitly updated

### Usage Examples

**Create a new project with PICS:**
```bash
th-cli project create --name "Matter Device Project" --pics-config-folder ./pics/xml/
```

**Update existing project with both config and PICS:**
```bash
th-cli project update --id 5 --config project-config.json --pics-config-folder ./pics/
```

**Update only the project name (preserves existing PICS):**
```bash
th-cli project update --id 5 --name "Renamed Project"
```

### Testing
- Unit Test ✅
- Sanity Test ✅
