### PR TITLE
[Fix] Project Create Command With No PICS

### DIFF
--- a/th_cli/commands/project.py
+++ b/th_cli/commands/project.py
@@ -38,7 +38,6 @@ from th_cli.utils import __print_json, read_pics_config
 from th_cli.validation import validate_directory_path
 
 TABLE_FORMAT = "{:<5} {:25} {:28}"
-EMPTY_PICS = PICS(clusters={})
 
 # Click command group for project management
 @click.group(
@@ -229,7 +228,7 @@ def _create_project(sync_apis: SyncApis, name: str, config: str | None, pics_con
             raise CLIError(f"Invalid configuration: {e}")
 
     # Process PICS configuration if provided
-    pics = EMPTY_PICS
+    pics = PICS(clusters={})
     if pics_config_folder:
         pics_path = validate_directory_path(pics_config_folder, must_exist=True)
         pics_dict = read_pics_config(str(pics_path))

--- a/th_cli/commands/project.py
+++ b/th_cli/commands/project.py
@@ -38,7 +38,7 @@ from th_cli.utils import __print_json, read_pics_config
 from th_cli.validation import validate_directory_path
 
 TABLE_FORMAT = "{:<5} {:25} {:28}"
-
+EMPTY_PICS = PICS(clusters={})
 
 # Click command group for project management
 @click.group(
@@ -229,7 +229,7 @@ def _create_project(sync_apis: SyncApis, name: str, config: str | None, pics_con
             raise CLIError(f"Invalid configuration: {e}")
 
     # Process PICS configuration if provided
-    pics = None
+    pics = EMPTY_PICS
     if pics_config_folder:
         pics_path = validate_directory_path(pics_config_folder, must_exist=True)
         pics_dict = read_pics_config(str(pics_path))


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/939
---

## Description
The CLI project create command is facing an error when no PICS is provided.
<img width="1302" height="69" alt="image" src="https://github.com/user-attachments/assets/92a03063-d58d-46ac-b008-1177048129a0" />

## Solution
The PICS should not receive directly the `None` value, but the PICS empty equivalent, consisting of 'clusters' being an empty dictionary. So now we're passing the suitable empty PICS value `{clusters={}}`:

<img width="864" height="35" alt="Screenshot 2026-04-02 at 10 02 38" src="https://github.com/user-attachments/assets/bea9d2f1-47a2-4b38-a61b-72342e077b5e" />

