### PR TITLE
[FEATURE] Update CLI with grouped logs download feature

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1566,7 +1566,24 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful Response"
+                        "description": "Successful Response",
+                        "content": {
+                            "application/zip": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        },
+                        "headers": {
+                            "Content-Disposition": {
+                                "description": "Suggests a filename for the downloaded ZIP file",
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "example": "attachment; filename=\"archive.zip\""
+                            }       
+                        }                 
                     },
                     "422": {
                         "description": "Validation Error",

--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -151,6 +151,9 @@ class OpenAPIParser:
                 if "application/json" in content:
                     schema = content["application/json"].get("schema", {})
                     return self._get_python_type(schema, resolve_ref=True)
+                if "application/zip" in content:
+                    schema = content["application/zip"].get("schema", {})
+                    return self._get_python_type(schema, resolve_ref=True)
 
         # Check for any 2xx response
         for status, response in responses.items():
@@ -808,6 +811,8 @@ class ApiClient:
             try:
                 # Use Pydantic v2 TypeAdapter for validation
                 adapter = TypeAdapter(type_)
+                if type_ == bytes:
+                    return adapter.validate_python(response.content)
                 return adapter.validate_python(response.json()) if type_ else response.text
             except Exception as e:
                 raise ResponseHandlingException(e)

--- a/th_cli/api_lib_autogen/api/test_run_executions_api.py
+++ b/th_cli/api_lib_autogen/api/test_run_executions_api.py
@@ -277,14 +277,14 @@ class _TestRunExecutionsApi:
 
     def _build_for_download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(
         self, id: int
-    ) -> Coroutine[Any, Any, None]:
+    ) -> Coroutine[Any, Any, bytes]:
         """
         Download Grouped Log
         """
         path_params = {"id": str(id)}
 
         return self.api_client.request(
-            type_=None, method="GET", url="/api/v1/test_run_executions/{id}/grouped-log", path_params=path_params
+            type_=bytes, method="GET", url="/api/v1/test_run_executions/{id}/grouped-log", path_params=path_params
         )
 
     def _build_for_upload_file_api_v1_test_run_executions_file_upload__post(
@@ -514,7 +514,7 @@ class AsyncTestRunExecutionsApi(_TestRunExecutionsApi):
             id=id, json_entries=json_entries, download=download
         )
 
-    async def download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(self, id: int) -> None:
+    async def download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(self, id: int) -> bytes:
         """
         Download Grouped Log
         """
@@ -706,7 +706,7 @@ class SyncTestRunExecutionsApi(_TestRunExecutionsApi):
         )
         return get_event_loop().run_until_complete(coroutine)
 
-    def download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(self, id: int) -> None:
+    def download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(self, id: int) -> bytes:
         """
         Download Grouped Log
         """

--- a/th_cli/api_lib_autogen/api_client.py
+++ b/th_cli/api_lib_autogen/api_client.py
@@ -118,6 +118,8 @@ class ApiClient:
             try:
                 # Use Pydantic v2 TypeAdapter for validation
                 adapter = TypeAdapter(type_)
+                if type_ == bytes:
+                    return adapter.validate_python(response.content)
                 return adapter.validate_python(response.json()) if type_ else response.text
             except Exception as e:
                 raise ResponseHandlingException(e)

--- a/th_cli/commands/test_run_execution.py
+++ b/th_cli/commands/test_run_execution.py
@@ -171,7 +171,7 @@ def list_executions(
             sync_apis = SyncApis(client)
 
             if log:
-                __fetch_test_run_execution_log(sync_apis, id)
+                __fetch_test_run_execution_log(sync_apis, id, None)
             elif id is not None:
                 __test_run_execution_by_id(sync_apis, id, json)
             else:
@@ -337,7 +337,7 @@ def __test_run_execution_batch(
         handle_api_error(e, "get test run executions")
 
 
-def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: str) -> None:
+def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: str | None) -> None:
     try:
         test_run_execution_api = sync_apis.test_run_executions_api
         log_content = test_run_execution_api.download_log_api_v1_test_run_executions__id__log_get(
@@ -346,7 +346,7 @@ def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: st
 
         if log_content:
             if output_file:
-                with open(output_file, "w") as outfile:
+                with open(output_file, "w", encoding="utf-8") as outfile:
                     outfile.write(log_content)
             else:
                 click.echo(log_content)
@@ -357,7 +357,7 @@ def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: st
         handle_api_error(e, "fetch test run execution log")
 
 
-def __fetch_grouped_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: str) -> None:
+def __fetch_grouped_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: str | None) -> None:
     try:
         test_run_execution_api = sync_apis.test_run_executions_api
         log_content = test_run_execution_api.download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(id=id)
@@ -368,11 +368,13 @@ def __fetch_grouped_test_run_execution_log(sync_apis: SyncApis, id: int, output_
                     id=id
                 )
                 if execution_data:
-                    output_file = execution_data.title + ".zip"
+                    import re
+
+                    output_file = re.sub(r"[^\w]", "", execution_data.title) + ".zip"
                 else:
                     output_file = f"test_run_execution_{id}_grouped.zip"
 
-            with open(output_file, "w") as outfile:
+            with open(output_file, "wb") as outfile:
                 outfile.write(log_content)
 
         else:

--- a/th_cli/commands/test_run_execution.py
+++ b/th_cli/commands/test_run_execution.py
@@ -27,71 +27,113 @@ from th_cli.utils import __print_json
 table_format_header = "{:<6} {:<55} {}"
 table_format = "{:<6} {} {}"
 
+_list_options = [
+    click.option(
+        "--id",
+        "-i",
+        default=None,
+        required=False,
+        type=int,
+        help=colorize_help("Fetch specific Test Run via ID"),
+    ),
+    click.option(
+        "--skip",
+        "-s",
+        default=None,
+        required=False,
+        type=int,
+        help=colorize_help("The first N Test Runs to skip, ordered by ID"),
+    ),
+    click.option(
+        "--limit",
+        "-l",
+        default=None,
+        required=False,
+        type=int,
+        help=colorize_help("Maximum number of test runs to fetch (default: 100)"),
+    ),
+    click.option(
+        "--sort",
+        default="desc",
+        required=False,
+        type=click.Choice(["asc", "desc"], case_sensitive=False),
+        help=colorize_help(
+            "Sort order for test runs by ID. 'desc' shows highest ID first, 'asc' shows lowest ID first"
+        ),
+    ),
+    click.option(
+        "--project-id",
+        "-p",
+        default=None,
+        required=False,
+        type=int,
+        help=colorize_help("Filter test runs by project ID"),
+    ),
+    click.option(
+        "--log",
+        is_flag=True,
+        default=False,
+        help=colorize_help("Fetch log content for the specified test run execution ID (requires --id)"),
+        deprecated="Use the log command",
+    ),
+    click.option(
+        "--json",
+        is_flag=True,
+        default=False,
+        help=colorize_help("Print JSON response for more details (not applicable with --log)"),
+    ),
+    click.option(
+        "--all",
+        is_flag=True,
+        default=False,
+        help=colorize_help("Fetch all test run executions with screen pagination (cannot be used with --limit)"),
+    ),
+]
 
-@click.command(
+
+def add_options(options):
+    def _add_options(func):
+        for option in reversed(options):  # reversed preserves order
+            func = option(func)
+        return func
+
+    return _add_options
+
+
+@click.group(
     short_help=colorize_help("Manage test run executions"),
     help=colorize_cmd_help(
         "test_run_execution", "List test run execution history or fetch logs for a specific execution"
     ),
+    invoke_without_command=True,
 )
-@click.option(
-    "--id",
-    "-i",
-    default=None,
-    required=False,
-    type=int,
-    help=colorize_help("Fetch specific Test Run via ID"),
-)
-@click.option(
-    "--skip",
-    "-s",
-    default=None,
-    required=False,
-    type=int,
-    help=colorize_help("The first N Test Runs to skip, ordered by ID"),
-)
-@click.option(
-    "--limit",
-    "-l",
-    default=None,
-    required=False,
-    type=int,
-    help=colorize_help("Maximum number of test runs to fetch (default: 100)"),
-)
-@click.option(
-    "--sort",
-    default="desc",
-    required=False,
-    type=click.Choice(["asc", "desc"], case_sensitive=False),
-    help=colorize_help("Sort order for test runs by ID. 'desc' shows highest ID first, 'asc' shows lowest ID first"),
-)
-@click.option(
-    "--project-id",
-    "-p",
-    default=None,
-    required=False,
-    type=int,
-    help=colorize_help("Filter test runs by project ID"),
-)
-@click.option(
-    "--log",
-    is_flag=True,
-    default=False,
-    help=colorize_help("Fetch log content for the specified test run execution ID (requires --id)"),
-)
-@click.option(
-    "--json",
-    is_flag=True,
-    default=False,
-    help=colorize_help("Print JSON response for more details (not applicable with --log)"),
-)
-@click.option(
-    "--all",
-    is_flag=True,
-    default=False,
-    help=colorize_help("Fetch all test run executions with screen pagination (cannot be used with --limit)"),
-)
+@click.pass_context
+# For the sake of backwards-compatibility, these arguments are applied to both the base command
+# as well as the list command
+@add_options(_list_options)
 def test_run_execution(
+    ctx,
+    id: int | None,
+    skip: int | None,
+    limit: int | None,
+    sort: str,
+    project_id: int | None,
+    log: bool,
+    json: bool,
+    all: bool,
+) -> None:
+    """Manage test run executions - list history or fetch logs"""
+    if ctx.invoked_subcommand is None:
+        ctx.forward(list_executions)
+
+
+@test_run_execution.command(
+    name="list",
+    short_help=colorize_help("List test run executions"),
+    help=colorize_cmd_help("list", "List test run execution history"),
+)
+@add_options(_list_options)
+def list_executions(
     id: int | None,
     skip: int | None,
     limit: int | None,
@@ -134,6 +176,44 @@ def test_run_execution(
                 __test_run_execution_by_id(sync_apis, id, json)
             else:
                 __test_run_execution_batch(sync_apis, json, skip, limit, sort, all, project_id)
+
+    except CLIError:
+        raise  # Re-raise CLI Errors as-is
+
+
+@test_run_execution.command(
+    short_help=colorize_help("Fetch test run execution logs"),
+    help=colorize_cmd_help("log", "Fetch logs for a specific execution"),
+)
+@click.option(
+    "--id",
+    "-i",
+    required=True,
+    type=int,
+    help=colorize_help("Fetch specific Test Run logs via ID"),
+)
+@click.option(
+    "--output-file",
+    "-o",
+    required=False,
+    type=str,
+    help=colorize_help("Output file. Test run execution title will be used by default"),
+)
+@click.option(
+    "--grouped",
+    is_flag=True,
+    default=False,
+    help=colorize_help("Download a zip archive of the grouped logs"),
+)
+def log(id: int, output_file: str, grouped: bool) -> None:
+    try:
+        with closing(get_client()) as client:
+            sync_apis = SyncApis(client)
+
+            if grouped:
+                __fetch_grouped_test_run_execution_log(sync_apis, id, output_file)
+            else:
+                __fetch_test_run_execution_log(sync_apis, id, output_file)
 
     except CLIError:
         raise  # Re-raise CLI Errors as-is
@@ -257,7 +337,7 @@ def __test_run_execution_batch(
         handle_api_error(e, "get test run executions")
 
 
-def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int) -> None:
+def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: str) -> None:
     try:
         test_run_execution_api = sync_apis.test_run_executions_api
         log_content = test_run_execution_api.download_log_api_v1_test_run_executions__id__log_get(
@@ -265,12 +345,41 @@ def __fetch_test_run_execution_log(sync_apis: SyncApis, id: int) -> None:
         )
 
         if log_content:
-            click.echo(log_content)
+            if output_file:
+                with open(output_file, "w") as outfile:
+                    outfile.write(log_content)
+            else:
+                click.echo(log_content)
         else:
             click.echo("No log content available for this test run execution.")
 
     except UnexpectedResponse as e:
         handle_api_error(e, "fetch test run execution log")
+
+
+def __fetch_grouped_test_run_execution_log(sync_apis: SyncApis, id: int, output_file: str) -> None:
+    try:
+        test_run_execution_api = sync_apis.test_run_executions_api
+        log_content = test_run_execution_api.download_grouped_log_api_v1_test_run_executions__id__grouped_log_get(id=id)
+
+        if log_content:
+            if not output_file:
+                execution_data = test_run_execution_api.read_test_run_execution_api_v1_test_run_executions__id__get(
+                    id=id
+                )
+                if execution_data:
+                    output_file = execution_data.title + ".zip"
+                else:
+                    output_file = f"test_run_execution_{id}_grouped.zip"
+
+            with open(output_file, "w") as outfile:
+                outfile.write(log_content)
+
+        else:
+            click.echo("No log content available for this test run execution.")
+
+    except UnexpectedResponse as e:
+        handle_api_error(e, "fetch grouped test run execution log")
 
 
 def __print_table_test_executions(test_execution: list) -> None:


### PR DESCRIPTION
### What changed
This PR implements grouped log archive downloads, a feature that exists on the web UI (and the API), but was not yet available in the CLI:

<img width="1914" height="525" alt="image" src="https://github.com/user-attachments/assets/dce1b2d5-cd81-4e24-8e0f-1e660e80e7bd" />

I've broken out the log fetching functionality into a separate group under the `test-run-execution` command:
<img width="811" height="233" alt="image" src="https://github.com/user-attachments/assets/712755df-a6f9-4e43-b994-eaa2412cab98" />

but also maintained the existing syntax/functionality in case there were users relying on it:
<img width="851" height="517" alt="image" src="https://github.com/user-attachments/assets/6163eea1-2ce4-49f1-8e8a-97481698246f" />

### Testing
Testing existing syntax for backwards-compatability:
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/d64f2639-01ce-49d4-98f0-9052ccaa58e5" />

New syntax for simple log download:
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/ae07f3e1-616f-4701-915d-4f1307373c6f" />

And new syntax for the new feature (with and without specifying output file):
<img width="1244" height="704" alt="image" src="https://github.com/user-attachments/assets/5276079b-fcc6-4466-a0d2-9558853bd122" />
