### PR TITLE
[CLI] Make per-run log files unique by appending timestamp + open with mode="w" (fixes #984)

### DIFF
--- a/th_cli/test_run/logging.py
+++ b/th_cli/test_run/logging.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 import os
 
 from loguru import logger
@@ -32,8 +33,12 @@ def configure_logger_for_run(title: str) -> str:
     # Reset (Remove all sinks from logger)
     logger.remove()
 
-    log_path = os.path.join(config.log_config.output_log_path, f"test_run_{title}.log")
+    timestamp = datetime.datetime.now().isoformat(timespec="seconds").replace(":", "-")
+    log_path = os.path.join(
+        config.log_config.output_log_path,
+        f"test_run_{title}_{timestamp}.log",
+    )
 
-    logger.add(log_path, enqueue=True, format=config.log_config.format)
+    logger.add(log_path, enqueue=True, format=config.log_config.format, mode="w")
 
     return log_path


### PR DESCRIPTION
Fixes #984.

Root cause: `configure_logger_for_run` in
`certification-tool-cli/th_cli/test_run/logging.py` derived the log file path
solely from `--title` (`test_run_{title}.log`) and `loguru.logger.add(...)`
defaults to append mode. Reusing `-n NAME` across runs caused successive runs
to be concatenated into the same file.
Change:
- Append a timestamp suffix (`_YYYY-MM-DD-HH-MM-SS`) to the log filename inside
  `configure_logger_for_run`, so every run produces a unique file regardless
  of the `-n NAME` value (matches the convention suggested by @OlivierGre).
- Pass `mode="w"` to `logger.add(...)` as defense-in-depth, in case two runs
  ever land on the exact same path (e.g. same second).
No public API change; `configure_logger_for_run(title)` still returns the
resolved path used by `run_tests` at the end of execution.
Verification:
- Run the same test twice with `-n my_run`. Two distinct files in `run_logs/`,
  each containing only its own run.