### PR TITLE
[Feature] Config Output To Project Command

### DIFF
--- a/th_cli/commands/project.py
+++ b/th_cli/commands/project.py
@@ -125,12 +125,14 @@ def create(name: str, config: str | None, pics_config_folder: str | None) -> Non
 )
 @click.option(
     "--json",
+    "-j",
     is_flag=True,
     default=False,
     help=colorize_help("Print JSON response for more details"),
 )
 @click.option(
     "--config",
+    "-c",
     is_flag=True,
     default=False,
     help=colorize_help("Print project configuration in JSON format")

--- a/th_cli/commands/project.py
+++ b/th_cli/commands/project.py
@@ -34,7 +34,7 @@ from th_cli.colorize import (
     italic,
 )
 from th_cli.exceptions import CLIError, handle_api_error, handle_file_error
-from th_cli.utils import __print_json, read_pics_config
+from th_cli.utils import __print_config, __print_json, read_pics_config
 from th_cli.validation import validate_directory_path
 
 TABLE_FORMAT = "{:<5} {:25} {:28}"
@@ -129,16 +129,23 @@ def create(name: str, config: str | None, pics_config_folder: str | None) -> Non
     default=False,
     help=colorize_help("Print JSON response for more details"),
 )
+@click.option(
+    "--config",
+    is_flag=True,
+    default=False,
+    help=colorize_help("Print project configuration in JSON format")
+)
 def list_projects(
     id: int | None,
     skip: int | None,
     limit: int | None,
     archived: bool,
     json: bool,
+    config: bool,
 ) -> None:
     """List projects"""
     with get_sync_apis("list") as sync_apis:
-        _list_projects(sync_apis, id, archived, skip, limit, json)
+        _list_projects(sync_apis, id, archived, skip, limit, json, config)
 
 
 # Click command to update an existing project
@@ -253,6 +260,7 @@ def _list_projects(
     skip: int | None,
     limit: int | None,
     json: bool,
+    config: bool,
 ) -> None:
     """List projects"""
 
@@ -300,6 +308,8 @@ def _list_projects(
 
     if json:
         __print_json(projects)
+    elif config:
+        __print_config(projects)
     else:
         __print_table(projects)
 

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -26,7 +26,7 @@ import tomli
 from th_cli.api_lib_autogen.api_client import SyncApis
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
 from th_cli.client import get_client
-from th_cli.colorize import colorize_dump
+from th_cli.colorize import colorize_dump, colorize_error
 from th_cli.config import find_git_root, get_package_root
 from th_cli.exceptions import CLIError, handle_file_error
 
@@ -38,6 +38,11 @@ DEFAULT_CLI_PROJECT_NAME = "CLI Project Execution"
 def __print_json(object: Any) -> None:
     click.echo(colorize_dump(__json_string(object)))
 
+def __print_config(object: Any) -> None:
+    if isinstance(object, list):
+        click.echo(colorize_error("Error: Please provide a single project to print the configuration."))
+        return
+    click.echo(colorize_dump(json.dumps(object.config, indent=4, default=str)))
 
 def __json_string(object: Any) -> str:
     if object is None:

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -26,7 +26,7 @@ import tomli
 from th_cli.api_lib_autogen.api_client import SyncApis
 from th_cli.api_lib_autogen.exceptions import UnexpectedResponse
 from th_cli.client import get_client
-from th_cli.colorize import colorize_dump, colorize_error
+from th_cli.colorize import colorize_dump
 from th_cli.config import find_git_root, get_package_root
 from th_cli.exceptions import CLIError, handle_file_error
 
@@ -38,11 +38,11 @@ DEFAULT_CLI_PROJECT_NAME = "CLI Project Execution"
 def __print_json(object: Any) -> None:
     click.echo(colorize_dump(__json_string(object)))
 
-def __print_config(object: Any) -> None:
-    if isinstance(object, list):
-        click.echo(colorize_error("Error: Please provide a single project to print the configuration."))
-        return
-    click.echo(colorize_dump(json.dumps(object.config, indent=4, default=str)))
+def __print_config(project: Any) -> None:
+    if isinstance(project, list):
+        raise CLIError("Please provide a single project ID (using --id) to print the configuration.")
+    config = project.config if project.config is not None else {}
+    click.echo(colorize_dump(json.dumps(config, indent=4, default=str)))
 
 def __json_string(object: Any) -> str:
     if object is None:


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/983
---

## Description
Simple addition of config output for CLI project command using the argument `--config`.

The pain point tackled here is when someone would like to create or update a project using another existing project configuration from the list. With this output, one can simply copy and paste to a file to use in project manipulation.

This feature requires a specific project to print the configuration, resulting in error otherwise (I fail to see value printing all the configurations for all existing projects without knowing each is each).
Please note that the `--json` argument will print more information than the project config, so using the new one would be more straight forward.

## Testing
Direct command test and simple sanity of the Project command.

### Screenshots
<img width="603" height="582" alt="Screenshot 2026-05-18 at 15 24 09" src="https://github.com/user-attachments/assets/f9f201ba-0f7e-4f94-b680-d5b42a97b3ab" />