### PR TITLE
[Fix] th-cli --version Surfaces Backend And SDK Versions (#999)

### DIFF
--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -426,7 +426,7 @@ def get_versions() -> dict:
         sync_apis = SyncApis(client)
         version_api = sync_apis.version_api
         versions_info = version_api.get_test_harness_backend_version_api_v1_version_get()
-        return versions_info.model_dump()
+        return versions_info.model_dump(mode='json')
     except CLIError:
         raise  # Re-raise CLI Errors as-is
     except UnexpectedResponse:

--- a/th_cli/utils.py
+++ b/th_cli/utils.py
@@ -426,7 +426,7 @@ def get_versions() -> dict:
         sync_apis = SyncApis(client)
         version_api = sync_apis.version_api
         versions_info = version_api.get_test_harness_backend_version_api_v1_version_get()
-        return versions_info
+        return versions_info.model_dump()
     except CLIError:
         raise  # Re-raise CLI Errors as-is
     except UnexpectedResponse:


### PR DESCRIPTION
## Summary

Fixes #999. `th-cli --version` now surfaces the backend and SDK versions returned by `GET /api/v1/version`.

## Root cause

`get_versions()` in `th_cli/utils.py` was annotated `-> dict` but actually returned a Pydantic `TestHarnessBackendVersion` instance from the autogenerated `SyncVersionApi`. The caller in `main.py::get_extended_help` iterated it with `.items()`, which raised `AttributeError` on the model. The bare `except Exception:` swallowed it and replaced the block with "Not able to retrieve versions from server.", so the five backend fields (`version`, `sha`, `sdk_sha`, `sdk_docker_tag`, `db_revision`) were dropped CLI-side even though the API response was fine.

## Fix

Convert the Pydantic v2 model to a `dict` via `model_dump()` in `get_versions()`. The existing `.items()` loop in `get_extended_help` then renders all backend fields without further changes.

<img width="531" height="245" alt="Screenshot 2026-05-25 at 12 53 52 PM" src="https://github.com/user-attachments/assets/5bee10c6-b225-4141-b56c-0fa17703ab99" />

