### PR TITLE
Fix parameter precedence in generated method signatures (#87)

### DIFF
--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -436,21 +436,19 @@ if TYPE_CHECKING:
         return_type = self.parser.get_response_type(responses)
 
         # Generate method signature
-        sig_params = []
+        req_sig, opt_sig = [], []
         if body_info:
-            type_hint = body_info["type"]
-            if not body_info["required"]:
-                type_hint = f"{type_hint} | None"
-                sig_params.append(f"body: {type_hint} = None")
+            if body_info["required"]:
+                req_sig.append(f"body: {body_info['type']}")
             else:
-                sig_params.append(f"body: {type_hint}")
-        
+                opt_sig.append(f"body: {body_info['type']} | None = None")
         for p in params:
             type_hint = f"{p['type']} | None" if not p["required"] else p["type"]
-            default = " = None" if not p["required"] else ""
-            sig_params.append(f"{p['name']}: {type_hint}{default}")
-
-        sig_params_str = ", ".join(sig_params)
+            if p["required"]:
+                req_sig.append(f"{p['name']}: {type_hint}")
+            else:
+                opt_sig.append(f"{p['name']}: {type_hint} = None")
+        sig_params_str = ", ".join(req_sig + opt_sig)
         if sig_params_str:
             sig_params_str = ", " + sig_params_str
 
@@ -599,24 +597,24 @@ if TYPE_CHECKING:
         return_type = self.parser.get_response_type(responses)
 
         # Generate method signature
-        sig_params = []
+        req_sig, opt_sig = [], []
         call_params = []
         if body_info:
-            type_hint = body_info["type"]
-            if not body_info["required"]:
-                type_hint = f"{type_hint} | None"
-                sig_params.append(f"body: {type_hint} = None")
+            if body_info["required"]:
+                req_sig.append(f"body: {body_info['type']}")
             else:
-                sig_params.append(f"body: {type_hint}")
+                opt_sig.append(f"body: {body_info['type']} | None = None")
             call_params.append("body=body")
 
         for p in params:
             type_hint = f"{p['type']} | None" if not p["required"] else p["type"]
-            default = " = None" if not p["required"] else ""
-            sig_params.append(f"{p['name']}: {type_hint}{default}")
+            if p["required"]:
+                req_sig.append(f"{p['name']}: {type_hint}")
+            else:
+                opt_sig.append(f"{p['name']}: {type_hint} = None")
             call_params.append(f"{p['name']}={p['name']}")
 
-        sig_params_str = ", ".join(sig_params)
+        sig_params_str = ", ".join(req_sig + opt_sig)
         if sig_params_str:
             sig_params_str = ", " + sig_params_str
 
@@ -660,25 +658,25 @@ if TYPE_CHECKING:
         return_type = self.parser.get_response_type(responses)
 
         # Generate method signature
-        sig_params = []
+        req_sig, opt_sig = [], []
         call_params = []
 
         if body_info:
-            type_hint = body_info["type"]
-            if not body_info["required"]:
-                type_hint = f"{type_hint} | None"
-                sig_params.append(f"body: {type_hint} = None")
+            if body_info["required"]:
+                req_sig.append(f"body: {body_info['type']}")
             else:
-                sig_params.append(f"body: {type_hint}")
+                opt_sig.append(f"body: {body_info['type']} | None = None")
             call_params.append("body=body")
-        
+
         for p in params:
             type_hint = f"{p['type']} | None" if not p["required"] else p["type"]
-            default = " = None" if not p["required"] else ""
-            sig_params.append(f"{p['name']}: {type_hint}{default}")
+            if p["required"]:
+                req_sig.append(f"{p['name']}: {type_hint}")
+            else:
+                opt_sig.append(f"{p['name']}: {type_hint} = None")
             call_params.append(f"{p['name']}={p['name']}")
 
-        sig_params_str = ", ".join(sig_params)
+        sig_params_str = ", ".join(req_sig + opt_sig)
         if sig_params_str:
             sig_params_str = ", " + sig_params_str
 

--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -443,11 +443,10 @@ if TYPE_CHECKING:
             else:
                 opt_sig.append(f"body: {body_info['type']} | None = None")
         for p in params:
-            type_hint = f"{p['type']} | None" if not p["required"] else p["type"]
             if p["required"]:
-                req_sig.append(f"{p['name']}: {type_hint}")
+                req_sig.append(f"{p['name']}: {p['type']}")
             else:
-                opt_sig.append(f"{p['name']}: {type_hint} = None")
+                opt_sig.append(f"{p['name']}: {p['type']} | None = None")
         sig_params_str = ", ".join(req_sig + opt_sig)
         if sig_params_str:
             sig_params_str = ", " + sig_params_str
@@ -607,11 +606,10 @@ if TYPE_CHECKING:
             call_params.append("body=body")
 
         for p in params:
-            type_hint = f"{p['type']} | None" if not p["required"] else p["type"]
             if p["required"]:
-                req_sig.append(f"{p['name']}: {type_hint}")
+                req_sig.append(f"{p['name']}: {p['type']}")
             else:
-                opt_sig.append(f"{p['name']}: {type_hint} = None")
+                opt_sig.append(f"{p['name']}: {p['type']} | None = None")
             call_params.append(f"{p['name']}={p['name']}")
 
         sig_params_str = ", ".join(req_sig + opt_sig)
@@ -669,11 +667,10 @@ if TYPE_CHECKING:
             call_params.append("body=body")
 
         for p in params:
-            type_hint = f"{p['type']} | None" if not p["required"] else p["type"]
             if p["required"]:
-                req_sig.append(f"{p['name']}: {type_hint}")
+                req_sig.append(f"{p['name']}: {p['type']}")
             else:
-                opt_sig.append(f"{p['name']}: {type_hint} = None")
+                opt_sig.append(f"{p['name']}: {p['type']} | None = None")
             call_params.append(f"{p['name']}={p['name']}")
 
         sig_params_str = ", ".join(req_sig + opt_sig)


### PR DESCRIPTION
## Summary
- Partition generated method-signature params into required/optional groups so non-default args always precede default args
- Applies the fix to all three sites: `_build_for_*`, `_generate_async_method`, and `_generate_sync_method` in `scripts/datamodel_generate_client.py`
- Prevents `SyntaxError` in the generated client when an optional `body` precedes a required path or query parameter

Closes #87

## Test plan
- [ ] Re-run the client generator and confirm the produced module imports without `SyntaxError`
- [ ] Spot-check a generated method that has both an optional body and a required path param — required arg should appear first

🤖 Generated with [Claude Code](https://claude.com/claude-code)