### PR TITLE
Fix indentation and typo in TODO comment (#88)

### DIFF
--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -171,7 +171,7 @@ class OpenAPIParser:
             ref = schema["$ref"]
             model_name = ref.split("/")[-1]
             if model_name.startswith("Body_"):
-            # TODO: handle schema names that conflicts with the models names.
+                # TODO: handle schema names that conflict with the models names.
                 model_name = "".join(word.capitalize() for word in model_name.split("_"))
             if resolve_ref:
                 return f"m.{model_name}"


### PR DESCRIPTION
## Summary
- Re-indent the TODO comment in `OpenAPIParser._get_python_type` so it sits inside the `if model_name.startswith("Body_"):` block it describes
- Fix typo: "conflicts" → "conflict"

Closes #88

## Test plan
- [ ] `python3 -m py_compile scripts/datamodel_generate_client.py`
- [ ] Visual review of the diff confirms the TODO is aligned with the block body

🤖 Generated with [Claude Code](https://claude.com/claude-code)