### PR TITLE
Fix example filename in main() docstring (#89)

### DIFF
--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -1015,9 +1015,9 @@ def main(input_spec: str, output_dir: str, import_name: str, verbose: bool):
     type-safe API client code with no postprocessing required.
 
     Example:
-        python scripts/generate_client_v2.py --input openapi.json
+        python scripts/datamodel_generate_client.py --input openapi.json
 
-        python scripts/generate_client_v2.py --input http://localhost/api/v1/openapi.json
+        python scripts/datamodel_generate_client.py --input http://localhost/api/v1/openapi.json
     """
     try:
         output_path = Path(output_dir)


### PR DESCRIPTION
## Summary
- Update the `Example:` block in `main()` to reference the actual script (`datamodel_generate_client.py`) instead of the stale `generate_client_v2.py`

Closes #89

## Test plan
- [ ] `python3 -m py_compile scripts/datamodel_generate_client.py`
- [ ] `python scripts/datamodel_generate_client.py --help` shows the corrected example

🤖 Generated with [Claude Code](https://claude.com/claude-code)