### PR TITLE
Prevent PydanticUserError in ApiClient.send for void endpoints (#90)

### DIFF
--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -810,10 +810,12 @@ class ApiClient:
         if response.status_code in [200, 201]:
             try:
                 # Use Pydantic v2 TypeAdapter for validation
+                if type_ is None:
+                    return None
                 adapter = TypeAdapter(type_)
                 if type_ == bytes:
                     return adapter.validate_python(response.content)
-                return adapter.validate_python(response.json()) if type_ else response.text
+                return adapter.validate_python(response.json())
             except Exception as e:
                 raise ResponseHandlingException(e)
         raise UnexpectedResponse.for_response(response)

--- a/scripts/datamodel_generate_client.py
+++ b/scripts/datamodel_generate_client.py
@@ -807,10 +807,10 @@ class ApiClient:
 
     async def send(self, request: Request, type_: Type[T]) -> T | str:
         response = await self.middleware(request, self.send_inner)
-        if response.status_code in [200, 201]:
+        if response.status_code in [200, 201, 204]:
             try:
                 # Use Pydantic v2 TypeAdapter for validation
-                if type_ is None:
+                if type_ is None or response.status_code == 204:
                     return None
                 adapter = TypeAdapter(type_)
                 if type_ == bytes:


### PR DESCRIPTION
## Summary
- In the generated `ApiClient.send`, return `None` immediately when `type_` is `None` instead of calling `TypeAdapter(type_)`, which raises `PydanticUserError`
- Aligns the runtime behaviour with the `type_: None -> None` overloads, fixing 204 No Content (and other void-response) endpoints

Closes #90

## Test plan
- [ ] `python3 -m py_compile scripts/datamodel_generate_client.py`
- [ ] Regenerate the client and exercise an endpoint with no response body — should return `None` without raising

🤖 Generated with [Claude Code](https://claude.com/claude-code)