### PR TITLE
[CP v2.16] Don't misreport successful log uploads as errors after WebSocket drop (#1062)

### DIFF
--- a/tests/test_run/test_prompt_manager.py
+++ b/tests/test_run/test_prompt_manager.py
@@ -20,7 +20,9 @@ import os
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import httpx
 import pytest
+import websockets
 
 from th_cli.shared_constants import MessageTypeEnum
 from th_cli.test_run import prompt_manager
@@ -374,6 +376,190 @@ class TestValidFileUpload:
 
         mock_send.assert_called_once()
         assert mock_send.call_args[1]["response"] == ""
+
+    @pytest.mark.asyncio
+    async def test_strips_trailing_whitespace_from_input(self):
+        """A stray trailing \\r or space from the input stream (e.g. some
+        terminals/SSH sessions send CRLF) must not cause a valid, existing
+        file path to be rejected as invalid."""
+        with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+            f.write(b"hello")
+            tmp_path = f.name
+
+        try:
+            with patch(
+                "th_cli.test_run.prompt_manager.__upload_file_and_send_response",
+                new_callable=AsyncMock,
+            ) as mock_upload:
+                with patch("aioconsole.ainput", new_callable=AsyncMock, return_value=f"{tmp_path}\r"):
+                    with patch("click.echo"):
+                        await prompt_manager.handle_file_upload_request(
+                            socket=AsyncMock(),
+                            request=MagicMock(prompt="Upload file", timeout=30),
+                        )
+
+            mock_upload.assert_called_once()
+            assert mock_upload.call_args[1]["file_path"] == tmp_path
+        finally:
+            os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# __upload_file_and_send_response
+# ---------------------------------------------------------------------------
+# `__upload_file_and_send_response` is a module-level name, so it is NOT
+# name-mangled. It's accessed here via getattr() to avoid writing the literal
+# dunder-prefixed attribute inside a class body, which *would* be mangled.
+
+
+def _get_upload_file_and_send_response():
+    return getattr(prompt_manager, "__upload_file_and_send_response")
+
+
+class _FakeAsyncClient:
+    """Minimal async context-manager stand-in for httpx.AsyncClient."""
+
+    def __init__(self, response=None, post_error=None):
+        self._response = response or MagicMock(status_code=200)
+        self._response.raise_for_status = Mock()
+        self._post_error = post_error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, *args, **kwargs):
+        if self._post_error:
+            raise self._post_error
+        return self._response
+
+
+@pytest.mark.unit
+class TestUploadFileAndSendResponse:
+    """Uploading the file and sending the prompt response are two separate
+    network operations. A failure sending the prompt response after a
+    successful upload must not be reported as an upload failure
+    (see GitHub issue #1062)."""
+
+    @pytest.mark.asyncio
+    async def test_success_sends_prompt_response(self):
+        upload_file_and_send_response = _get_upload_file_and_send_response()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"hello")
+            tmp_path = f.name
+
+        try:
+            with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
+                with patch("httpx.AsyncClient", return_value=_FakeAsyncClient()):
+                    with patch("click.echo"):
+                        await upload_file_and_send_response(
+                            socket=AsyncMock(),
+                            file_path=tmp_path,
+                            prompt=MagicMock(message_id=1),
+                        )
+
+            mock_send.assert_called_once()
+            assert mock_send.call_args[1]["response"] == "SUCCESS"
+        finally:
+            os.unlink(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_websocket_closed_after_successful_upload_reports_warning_not_error(self):
+        """If the upload succeeds but the websocket is closed before the
+        confirmation can be sent, this must be surfaced as a warning about the
+        lost confirmation - not as an upload error - since the file was
+        already uploaded successfully."""
+        upload_file_and_send_response = _get_upload_file_and_send_response()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"hello")
+            tmp_path = f.name
+
+        try:
+            with patch(
+                "th_cli.test_run.prompt_manager._send_prompt_response",
+                new_callable=AsyncMock,
+                side_effect=websockets.exceptions.ConnectionClosedError(None, None, None),
+            ):
+                with patch("httpx.AsyncClient", return_value=_FakeAsyncClient()):
+                    with patch("click.echo") as mock_echo:
+                        await upload_file_and_send_response(
+                            socket=AsyncMock(),
+                            file_path=tmp_path,
+                            prompt=MagicMock(message_id=1),
+                        )
+
+            echoed = " ".join(str(call.args[0]) for call in mock_echo.call_args_list)
+            assert "uploaded successfully" in echoed
+            assert "Unexpected error uploading file" not in echoed
+        finally:
+            os.unlink(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_other_exception_after_successful_upload_reports_warning_not_error(self):
+        """Any exception sending the confirmation (not just ConnectionClosed -
+        e.g. websockets.exceptions.InvalidState, or a plain OSError) must also
+        be reported as a post-upload notification warning, not an upload
+        error, since the upload already succeeded by this point."""
+        upload_file_and_send_response = _get_upload_file_and_send_response()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"hello")
+            tmp_path = f.name
+
+        try:
+            with patch(
+                "th_cli.test_run.prompt_manager._send_prompt_response",
+                new_callable=AsyncMock,
+                side_effect=OSError("socket already closed"),
+            ):
+                with patch("httpx.AsyncClient", return_value=_FakeAsyncClient()):
+                    with patch("click.echo") as mock_echo:
+                        await upload_file_and_send_response(
+                            socket=AsyncMock(),
+                            file_path=tmp_path,
+                            prompt=MagicMock(message_id=1),
+                        )
+
+            echoed = " ".join(str(call.args[0]) for call in mock_echo.call_args_list)
+            assert "uploaded successfully" in echoed
+            assert "confirmation could not be sent" in echoed
+            assert "Unexpected error uploading file" not in echoed
+        finally:
+            os.unlink(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_http_error_during_upload_still_reports_error(self):
+        """A failure during the actual upload (before success) must still be
+        reported as an upload error, and the empty response must be sent."""
+        upload_file_and_send_response = _get_upload_file_and_send_response()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"hello")
+            tmp_path = f.name
+
+        try:
+            with patch("th_cli.test_run.prompt_manager._send_prompt_response", new_callable=AsyncMock) as mock_send:
+                with patch(
+                    "httpx.AsyncClient",
+                    return_value=_FakeAsyncClient(post_error=httpx.ConnectError("boom")),
+                ):
+                    with patch("click.echo") as mock_echo:
+                        await upload_file_and_send_response(
+                            socket=AsyncMock(),
+                            file_path=tmp_path,
+                            prompt=MagicMock(message_id=1),
+                        )
+
+            mock_send.assert_called_once()
+            assert mock_send.call_args[1]["response"] == ""
+            echoed = " ".join(str(call.args[0]) for call in mock_echo.call_args_list)
+            assert "Network error during file upload" in echoed
+        finally:
+            os.unlink(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/th_cli/test_run/prompt_manager.py
+++ b/th_cli/test_run/prompt_manager.py
@@ -480,10 +480,10 @@ async def __prompt_user_for_file_upload(prompt: PromptRequest) -> str:
         click.echo("Enter the path to the file to upload (or press Enter to skip): ")
 
         # Wait for input async
-        file_path = await aioconsole.ainput()
+        file_path = (await aioconsole.ainput()).strip()
 
         # If user just pressed Enter, return empty string
-        if not file_path.strip():
+        if not file_path:
             return ""
 
         # Validate file path and type
@@ -531,7 +531,22 @@ async def __upload_file_and_send_response(
 
                 response.raise_for_status()
                 click.echo("✅ File uploaded successfully")
-                await _send_prompt_response(socket=socket, response="SUCCESS", prompt=prompt)
+
+        # The upload itself succeeded at this point (the HTTP response was already
+        # received above). Uploading a large log can keep the backend's event loop
+        # busy long enough that the WebSocket's keepalive ping/pong times out and
+        # the connection is dropped before we get a chance to send the prompt
+        # response. Any failure sending that response is therefore a post-upload
+        # notification failure, not an upload failure - report it separately so
+        # it isn't mistaken for one (see GitHub issue #1062).
+        try:
+            await _send_prompt_response(socket=socket, response="SUCCESS", prompt=prompt)
+        except Exception as e:
+            click.echo(
+                "⚠️  File was uploaded successfully, but the confirmation could not be sent "
+                f"to the backend: {e}",
+                err=True,
+            )
 
     except httpx.RequestError as e:
         click.echo(f"❌ Network error during file upload: {str(e)}", err=True)


### PR DESCRIPTION
## Summary

Cherry-pick of the merged fix for #1062 (THCLI misreports successful log uploads as errors after a WebSocket drop) onto `v2.16-cli-develop`, for the Matter v1.7 TE2 release line.

Original PR: #105 (merged to `v2.15.1-cli-develop` as `0f00720`).

## Contents

Single cherry-picked commit (squash-merge of #105, including review fixes for exception scope and a related trailing-whitespace/CR bug found in the same function):

- `__upload_file_and_send_response` now wraps only the `_send_prompt_response()` call in its own `except Exception` handler, separate from the upload's own error handling, so a WebSocket drop *after* a successful upload is reported as a distinct warning instead of `❌ Unexpected error uploading file`.
- `__prompt_user_for_file_upload` now strips the raw input once (trailing `\r`/whitespace from some terminals/SSH sessions was previously causing a valid, existing file path to be rejected as invalid).
- Unit tests covering: successful upload + response, WebSocket-closed-after-success (both `ConnectionClosed` and generic exceptions), an actual upload failure (unchanged behavior), and the whitespace-stripping fix.

## Testing

Cherry-picked cleanly with no conflicts (`prompt_manager.py` hadn't diverged between the two branches). Verified syntax with `py_compile`.
